### PR TITLE
Add support for adding a payment method without specifying the customer

### DIFF
--- a/src/AbstractVindiciaGateway.php
+++ b/src/AbstractVindiciaGateway.php
@@ -411,7 +411,7 @@ abstract class AbstractVindiciaGateway extends AbstractGateway
      *
      * @param string $class The request class name
      * @param array $parameters
-     * @pram bool $isUpdate default false
+     * @param bool $isUpdate default false
      * @return \Omnipay\Vindicia\Message\AbstractRequest
      */
     protected function createRequest($class, array $parameters, $isUpdate = false)

--- a/src/Message/AbstractHOARequest.php
+++ b/src/Message/AbstractHOARequest.php
@@ -12,7 +12,7 @@ use Omnipay\Vindicia\AttributeBag;
 
 abstract class AbstractHOARequest extends AbstractRequest
 {
-    public static $REGULAR_REQUEST_CLASS = 'Omnipay\Vindicia\Message\AbstractRequest';
+    protected static $REGULAR_REQUEST_CLASS = '\Omnipay\Vindicia\Message\AbstractRequest';
 
     /**
      * The corresponding regular (non-HOA) request. This is used to fake
@@ -203,18 +203,6 @@ abstract class AbstractHOARequest extends AbstractRequest
                 );
             }
             return $values;
-
-
-
-
-            // $values = array();
-            // foreach ($member as $key => $value) {
-            //     $values = array_merge(
-            //         $this->buildPrivateFormValues($keySoFar . '_' . $key, $value),
-            //         $values
-            //     );
-            // }
-            // return $values;
         } elseif (isset($member)) {
             return array(new NameValue($keySoFar, $member));
         } else {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -76,6 +76,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     const DEFAULT_MIN_CHARGEBACK_PROBABILITY = 100;
 
     /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\Response';
+
+    /**
      * Create a new Request
      *
      * @param ClientInterface $httpClient  A Guzzle client to make API calls with
@@ -637,7 +644,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         ini_set('soap.wsdl_cache_ttl', $originalWsdlCacheTtl);
         ini_set('default_socket_timeout', $originalSocketTimeout);
 
-        $this->response = $this->buildResponse($response);
+        $this->response = new static::$RESPONSE_CLASS($this, $response);
         return $this->response;
     }
 
@@ -651,11 +658,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
          * @var Response
          */
         return parent::send();
-    }
-
-    protected function buildResponse($response)
-    {
-        return new Response($this, $response);
     }
 
     protected function isUpdate()

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -84,6 +84,13 @@ use Omnipay\Common\Exception\InvalidRequestException;
 class CaptureRequest extends AbstractRequest
 {
     /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\CaptureResponse';
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @return string
@@ -129,16 +136,5 @@ class CaptureRequest extends AbstractRequest
          * @var CaptureResponse
          */
         return parent::send();
-    }
-
-    /**
-     * Use a special response object for Capture requests.
-     *
-     * @param object $response
-     * @return CaptureResponse
-     */
-    protected function buildResponse($response)
-    {
-        return new CaptureResponse($this, $response);
     }
 }

--- a/src/Message/CaptureResponse.php
+++ b/src/Message/CaptureResponse.php
@@ -26,7 +26,7 @@ class CaptureResponse extends Response
         // Check all the other response codes that come back and make sure they match up
         if ($success
             && (!isset($this->data->return)
-                || intval($this->data->return->returnCode) !== self::SUCCESS_CODE
+                || !in_array(intval($this->data->return->returnCode), static::getSuccessCodes(), true)
                 || intval($this->data->qtySuccess) !== 1
                 || intval($this->data->qtyFail) !== 0
             )

--- a/src/Message/CompleteHOARequest.php
+++ b/src/Message/CompleteHOARequest.php
@@ -20,6 +20,13 @@ use stdClass;
 class CompleteHOARequest extends AbstractRequest
 {
     /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\CompleteHOAResponse';
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @return string
@@ -79,10 +86,5 @@ class CompleteHOARequest extends AbstractRequest
          * @var CompleteHOAResponse
          */
         return parent::send();
-    }
-
-    protected function buildResponse($response)
-    {
-        return new CompleteHOAResponse($this, $response);
     }
 }

--- a/src/Message/CompleteHOAResponse.php
+++ b/src/Message/CompleteHOAResponse.php
@@ -4,7 +4,7 @@
  * they include a response for the method that was actually
  * called by HOA. If the request itself fails, we return its
  * error message and code. Otherwise, we return the status
- * for the method called by HOA. getFailureType or
+ * for the method called by HOA.
  * isRequestFailure and isMethodFailure can be used to
  * determine if it was a request failure or method failure.
  */
@@ -13,6 +13,7 @@ namespace Omnipay\Vindicia\Message;
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Common\Message\RequestInterface;
 use Omnipay\Vindicia\Attribute;
+use ReflectionClass;
 
 class CompleteHOAResponse extends Response
 {
@@ -32,6 +33,10 @@ class CompleteHOAResponse extends Response
      * @var string|null
      */
     protected $failureType;
+    /**
+     * @var bool
+     */
+    protected $isSuccessful;
 
     // Cached objects:
     protected $formValues;
@@ -60,16 +65,45 @@ class CompleteHOAResponse extends Response
         if (isset($this->data->session->apiReturn)) {
             $this->code = $this->data->session->apiReturn->returnCode;
             $this->message = $this->data->session->apiReturn->returnString;
-            if (!$this->isSuccessful()) {
+
+            if ($this->wasAuthorize()) {
+                $requestClass = '\Omnipay\Vindicia\Message\HOAAuthorizeRequest';
+            } elseif ($this->wasPurchase()) {
+                $requestClass = '\Omnipay\Vindicia\Message\HOAPurchaseRequest';
+            } elseif ($this->wasCreatePaymentMethod()) {
+                $requestClass = '\Omnipay\Vindicia\Message\HOACreatePaymentMethodRequest';
+            } elseif ($this->wasCreateSubscription()) {
+                $requestClass = '\Omnipay\Vindicia\Message\HOACreateSubscriptionRequest';
+            } else {
+                // sometimes Vindicia doesn't return any method info on a failure
+                $this->isSuccessful = false;
+                $this->failureType = self::METHOD_FAILURE;
+                return;
+            }
+
+            $requestReflection = new ReflectionClass($requestClass);
+            $regularRequestClassProperty = $requestReflection->getProperty('REGULAR_REQUEST_CLASS');
+            $regularRequestClassProperty->setAccessible(true);
+            $regularRequestClass = $regularRequestClassProperty->getValue();
+            $regularRequestClassReflection = new ReflectionClass($regularRequestClass);
+            $regularRequestResponseClassProperty = $regularRequestClassReflection->getProperty('RESPONSE_CLASS');
+            $regularRequestResponseClassProperty->setAccessible(true);
+            $regularRequestResponseClass = $regularRequestResponseClassProperty->getValue();
+            $regularRequestResponseSuccessCodes = $regularRequestResponseClass::getSuccessCodes();
+
+            $this->isSuccessful = in_array(intval($this->getCode()), $regularRequestResponseSuccessCodes, true);
+            if (!$this->isSuccessful) {
                 $this->failureType = self::METHOD_FAILURE;
             }
+
             return;
         }
 
         // otherwise, we want the response from the request
         $this->code = parent::getCode();
         $this->message = parent::getMessage();
-        if (!$this->isSuccessful()) {
+        $this->isSuccessful = parent::isSuccessful();
+        if (!$this->isSuccessful) {
             $this->failureType = self::REQUEST_FAILURE;
         }
     }
@@ -102,6 +136,11 @@ class CompleteHOAResponse extends Response
             return $this->code;
         }
         throw new InvalidResponseException('Response has no code.');
+    }
+
+    public function isSuccessful()
+    {
+        return $this->isSuccessful;
     }
 
     public function getTransaction()
@@ -154,6 +193,7 @@ class CompleteHOAResponse extends Response
      * method called by HOA failed. Returns null if the request was successful.
      *
      * @return string|null
+     * @deprecated
      */
     public function getFailureType()
     {
@@ -248,7 +288,10 @@ class CompleteHOAResponse extends Response
      */
     public function wasCreatePaymentMethod()
     {
-        return $this->getMethod() === 'accountUpdatePaymentMethod';
+        return in_array($this->getMethod(), array(
+            'accountUpdatePaymentMethod',
+            'paymentMethodUpdate' // @todo double check this
+        ), true);
     }
 
     /**

--- a/src/Message/CreatePayPalSubscriptionRequest.php
+++ b/src/Message/CreatePayPalSubscriptionRequest.php
@@ -111,6 +111,13 @@ namespace Omnipay\Vindicia\Message;
  */
 class CreatePayPalSubscriptionRequest extends CreateSubscriptionRequest
 {
+    /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\CreatePayPalSubscriptionResponse';
+
     public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
         $this->validate('returnUrl', 'cancelUrl');
@@ -128,16 +135,5 @@ class CreatePayPalSubscriptionRequest extends CreateSubscriptionRequest
          * @var CreatePayPalSubscriptionResponse
          */
         return parent::send();
-    }
-
-    /**
-     * Use a special response object for PayPal subscription requests.
-     *
-     * @param object $response
-     * @return CreatePayPalSubscriptionResponse
-     */
-    protected function buildResponse($response)
-    {
-        return new CreatePayPalSubscriptionResponse($this, $response);
     }
 }

--- a/src/Message/CreatePaymentMethodResponse.php
+++ b/src/Message/CreatePaymentMethodResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+class CreatePaymentMethodResponse extends Response
+{
+    protected static $SUCCESS_CODES = array(
+        200,
+        228, // Payment method saved but missing associated account - unable to replace on autobills
+        261  // All active AutoBills were updated. AutoBills which are both expired and Suspended cannot be updated.
+    );
+}

--- a/src/Message/HOAAuthorizeRequest.php
+++ b/src/Message/HOAAuthorizeRequest.php
@@ -102,7 +102,7 @@ use Omnipay\Vindicia\NameValue;
  */
 class HOAAuthorizeRequest extends AbstractHOARequest
 {
-    public static $REGULAR_REQUEST_CLASS = 'Omnipay\Vindicia\Message\AuthorizeRequest';
+    protected static $REGULAR_REQUEST_CLASS = '\Omnipay\Vindicia\Message\AuthorizeRequest';
 
     protected function getObjectParamNames()
     {

--- a/src/Message/HOACreateSubscriptionRequest.php
+++ b/src/Message/HOACreateSubscriptionRequest.php
@@ -112,7 +112,7 @@ use Omnipay\Vindicia\NameValue;
  */
 class HOACreateSubscriptionRequest extends AbstractHOARequest
 {
-    public static $REGULAR_REQUEST_CLASS = 'Omnipay\Vindicia\Message\CreateSubscriptionRequest';
+    protected static $REGULAR_REQUEST_CLASS = '\Omnipay\Vindicia\Message\CreateSubscriptionRequest';
 
     protected function getObjectParamNames()
     {

--- a/src/Message/HOAPurchaseRequest.php
+++ b/src/Message/HOAPurchaseRequest.php
@@ -83,7 +83,7 @@ use Omnipay\Vindicia\NameValue;
  */
 class HOAPurchaseRequest extends HOAAuthorizeRequest
 {
-    public static $REGULAR_REQUEST_CLASS = 'Omnipay\Vindicia\Message\PurchaseRequest';
+    protected static $REGULAR_REQUEST_CLASS = '\Omnipay\Vindicia\Message\PurchaseRequest';
 
     protected function getMethodParamValues()
     {

--- a/src/Message/PayPalPurchaseRequest.php
+++ b/src/Message/PayPalPurchaseRequest.php
@@ -68,6 +68,13 @@ namespace Omnipay\Vindicia\Message;
  */
 class PayPalPurchaseRequest extends PurchaseRequest
 {
+    /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\PayPalPurchaseResponse';
+
     public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
         $this->validate('returnUrl', 'cancelUrl');
@@ -85,16 +92,5 @@ class PayPalPurchaseRequest extends PurchaseRequest
          * @var PayPalPurchaseResponse
          */
         return parent::send();
-    }
-
-    /**
-     * Use a special response object for PayPal purchase requests.
-     *
-     * @param object $response
-     * @return PayPalPurchaseResponse
-     */
-    protected function buildResponse($response)
-    {
-        return new PayPalPurchaseResponse($this, $response);
     }
 }

--- a/src/Message/PayPalPurchaseResponse.php
+++ b/src/Message/PayPalPurchaseResponse.php
@@ -13,7 +13,7 @@ class PayPalPurchaseResponse extends Response
      */
     public function isSuccessful()
     {
-        return intval($this->getCode()) === self::SUCCESS_CODE && $this->getRedirectUrl();
+        return parent::isSuccessful() && $this->getRedirectUrl();
     }
 
     /**

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -101,6 +101,13 @@ use Omnipay\Vindicia\VindiciaRefundItemBag;
 class RefundRequest extends AbstractRequest
 {
     /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\RefundResponse';
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @return string
@@ -234,16 +241,5 @@ class RefundRequest extends AbstractRequest
          * @var RefundResponse
          */
         return parent::send();
-    }
-
-    /**
-     * Use a special response object for Refund requests.
-     *
-     * @param object $response
-     * @return RefundResponse
-     */
-    protected function buildResponse($response)
-    {
-        return new RefundResponse($this, $response);
     }
 }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -9,7 +9,7 @@ use Omnipay\Common\Message\RequestInterface;
 
 class Response extends AbstractResponse
 {
-    const SUCCESS_CODE = 200;
+    protected static $SUCCESS_CODES = array(200);
 
     protected $objectHelper;
 
@@ -47,7 +47,7 @@ class Response extends AbstractResponse
      */
     public function isSuccessful()
     {
-        return intval($this->getCode()) === self::SUCCESS_CODE;
+        return in_array(intval($this->getCode()), static::getSuccessCodes(), true);
     }
 
     /**
@@ -461,5 +461,15 @@ class Response extends AbstractResponse
          * @var AbstractRequest
          */
         return parent::getRequest();
+    }
+
+    /**
+     * Get the codes that indicate success
+     *
+     * @return array<int>
+     */
+    public static function getSuccessCodes()
+    {
+        return static::$SUCCESS_CODES;
     }
 }

--- a/src/TestFramework/Mocker.php
+++ b/src/TestFramework/Mocker.php
@@ -23,8 +23,10 @@ class Mocker extends Mockery
         $regularRequestProperty = $requestReflection->getProperty('regularRequest');
         $regularRequestProperty->setAccessible(true);
         // the regularRequest instance object must be mocked as well
-        $regularRequest = self::mock($requestClass::$REGULAR_REQUEST_CLASS)
-                            ->makePartial()->shouldAllowMockingProtectedMethods();
+        $regularRequestClassProperty = $requestReflection->getProperty('REGULAR_REQUEST_CLASS');
+        $regularRequestClassProperty->setAccessible(true);
+        $regularRequestClass = $regularRequestClassProperty->getValue();
+        $regularRequest = self::mock($regularRequestClass)->makePartial()->shouldAllowMockingProtectedMethods();
         $regularRequestProperty->setValue($request, $regularRequest);
 
         return $request;

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -301,7 +301,6 @@ class AbstractRequestTest extends SoapTestCase
         TestableSoapClient::setNextResponse(new stdClass());
 
         $this->request->shouldReceive('getObject')->andReturn($object);
-        $this->request->shouldReceive('buildResponse')->andReturn(null);
         $this->request->shouldReceive('getTestMode')->andReturn(true);
         $this->request->shouldReceive('getUsername')->andReturn($this->username);
         $this->request->shouldReceive('getPassword')->andReturn($this->password);

--- a/tests/Message/HOACreatePaymentMethodRequestTest.php
+++ b/tests/Message/HOACreatePaymentMethodRequestTest.php
@@ -159,6 +159,67 @@ class HOACreatePaymentMethodRequestTest extends SoapTestCase
             new NameValue('Account_UpdatePaymentMethod_updateBehavior', $this->validate ? CreatePaymentMethodRequest::VALIDATE_CARD : CreatePaymentMethodRequest::SKIP_CARD_VALIDATION),
             $data['session']->methodParamValues
         ));
+        $this->assertTrue(in_array(
+            new NameValue('Account_UpdatePaymentMethod_replaceOnAllAutoBills', true),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('Account_UpdatePaymentMethod_ignoreAvsPolicy', false),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('Account_UpdatePaymentMethod_ignoreCvnPolicy', false),
+            $data['session']->methodParamValues
+        ));
+
+        $this->assertSame('initialize', $data['action']);
+    }
+
+    public function testGetDataNoCustomer()
+    {
+        $this->request->setCustomerId(null)->setCustomerReference(null);
+        $data = $this->request->getData();
+
+        $this->assertSame($this->returnUrl, $data['session']->returnURL);
+        $this->assertSame($this->errorUrl, $data['session']->errorURL);
+        $this->assertSame('PaymentMethod_update', $data['session']->method);
+        $this->assertSame($this->ip, $data['session']->ipAddress);
+        $numHOAAttributes = count($this->HOAAttributes);
+        $this->assertSame($numHOAAttributes, count($data['session']->nameValues));
+        for ($i = 0; $i < $numHOAAttributes; $i++) {
+            $this->assertSame($this->HOAAttributes[$i]['name'], $data['session']->nameValues[$i]->name);
+            $this->assertSame($this->HOAAttributes[$i]['value'], $data['session']->nameValues[$i]->value);
+        }
+        $this->assertSame(AbstractRequest::API_VERSION, $data['session']->version);
+
+        $this->assertTrue(in_array(
+            new NameValue('vin_PaymentMethod_merchantPaymentMethodId', $this->paymentMethodId),
+            $data['session']->privateFormValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('vin_PaymentMethod_VID', $this->paymentMethodReference),
+            $data['session']->privateFormValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('PaymentMethod_Update_validate', $this->validate),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('PaymentMethod_Update_replaceOnAllAutoBills', true),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('PaymentMethod_Update_replaceOnAllChildAutoBills', true),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('PaymentMethod_Update_ignoreAvsPolicy', false),
+            $data['session']->methodParamValues
+        ));
+        $this->assertTrue(in_array(
+            new NameValue('PaymentMethod_Update_ignoreCvnPolicy', false),
+            $data['session']->methodParamValues
+        ));
 
         $this->assertSame('initialize', $data['action']);
     }

--- a/tests/Mock/CreatePaymentMethodNoCustomer228Success.xml
+++ b/tests/Mock/CreatePaymentMethodNoCustomer228Success.xml
@@ -1,0 +1,66 @@
+<soap:Envelope
+    soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:vin="http://soap.vindicia.com/v18_0/Vindicia"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <updateResponse xmlns="http://soap.vindicia.com/v18_0/PaymentMethod">
+      <return xmlns="" xsi:type="vin:Return">
+        <returnCode xsi:type="vin:ReturnCode">228</returnCode>
+        <soapId xsi:type="xsd:string">1234567890abcdef1234567890abcdef</soapId>
+        <returnString xsi:type="xsd:string">Payment method saved but missing associated account - unable to replace on autobills </returnString>
+      </return>
+      <paymentMethod xmlns="" xsi:type="vin:PaymentMethod">
+        <VID xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_REFERENCE]</VID>
+        <type xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</type>
+        <creditCard xmlns="" xsi:type="vin:CreditCard">
+          <account xmlns="" xsi:type="xsd:string">[CARD_FIRST_SIX]XXXXXX[CARD_LAST_FOUR]</account>
+          <bin xmlns="" xsi:type="xsd:string">[CARD_FIRST_SIX]</bin>
+          <lastDigits xmlns="" xsi:type="xsd:string">[CARD_LAST_FOUR]</lastDigits>
+          <accountLength xmlns="" xsi:type="xsd:int">16</accountLength>
+          <expirationDate xmlns="" xsi:type="xsd:string">[EXPIRY_YEAR][EXPIRY_MONTH]</expirationDate>
+          <extendedCardAttributes xmlns="" xsi:type="vin:ExtendedCardAttributes">
+            <CommercialCard xmlns="" xsi:type="xsd:int">0</CommercialCard>
+            <SignatureDebitCard xmlns="" xsi:type="xsd:int">0</SignatureDebitCard>
+            <PINlessDebitCard xmlns="" xsi:type="xsd:int">0</PINlessDebitCard>
+            <PrepaidCard xmlns="" xsi:type="xsd:int">0</PrepaidCard>
+            <PayrollCard xmlns="" xsi:type="xsd:int">0</PayrollCard>
+            <HealthcareCard xmlns="" xsi:type="xsd:int">0</HealthcareCard>
+            <CountryOfIssuance xmlns="" xsi:type="xsd:string">USA</CountryOfIssuance>
+            <DurbinRegulated xmlns="" xsi:type="xsd:int">0</DurbinRegulated>
+            <Affluent xmlns="" xsi:type="xsd:int">0</Affluent>
+          </extendedCardAttributes>
+          <VID xmlns="" xsi:type="xsd:string">0123456789fedcba0123456789fedcba</VID>
+        </creditCard>
+        <merchantPaymentMethodId xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_ID]</merchantPaymentMethodId>
+        <sortOrder xmlns="" xsi:type="xsd:int">0</sortOrder>
+        <active xmlns="" xsi:type="xsd:boolean">1</active>
+      </paymentMethod>
+      <created xmlns="" xsi:type="xsd:boolean">1</created>
+      <validated xmlns="" xsi:type="xsd:boolean">1</validated>
+      <score xmlns="" xsi:type="xsd:int">-1</score>
+      <authStatus xmlns="" xsi:type="vin:TransactionStatus">
+        <status xmlns="" xsi:type="vin:TransactionStatusType">AuthorizedForValidation</status>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-12-07T06:30:40-08:00</timestamp>
+        <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
+        <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
+          <authCode xmlns="" xsi:type="xsd:string">[AUTHORIZATION_CODE]</authCode>
+          <avsCode xmlns="" xsi:type="xsd:string">[AVS_CODE]</avsCode>
+          <extendedCardAttributes xmlns="" xsi:type="vin:ExtendedCardAttributes">
+            <CommercialCard xmlns="" xsi:type="xsd:int">0</CommercialCard>
+            <SignatureDebitCard xmlns="" xsi:type="xsd:int">0</SignatureDebitCard>
+            <PINlessDebitCard xmlns="" xsi:type="xsd:int">0</PINlessDebitCard>
+            <PrepaidCard xmlns="" xsi:type="xsd:int">0</PrepaidCard>
+            <PayrollCard xmlns="" xsi:type="xsd:int">0</PayrollCard>
+            <HealthcareCard xmlns="" xsi:type="xsd:int">0</HealthcareCard>
+            <CountryOfIssuance xmlns="" xsi:type="xsd:string">[COUNTRY]</CountryOfIssuance>
+            <DurbinRegulated xmlns="" xsi:type="xsd:int">0</DurbinRegulated>
+            <Affluent xmlns="" xsi:type="xsd:int">0</Affluent>
+          </extendedCardAttributes>
+        </creditCardStatus>
+      </authStatus>
+    </updateResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/tests/Mock/CreatePaymentMethodNoCustomerSuccess.xml
+++ b/tests/Mock/CreatePaymentMethodNoCustomerSuccess.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope
+    soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:vin="http://soap.vindicia.com/v18_0/Vindicia"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <updateResponse xmlns="http://soap.vindicia.com/v18_0/PaymentMethod">
+      <return xmlns="" xsi:type="vin:Return">
+        <returnCode xsi:type="vin:ReturnCode">200</returnCode>
+        <soapId xsi:type="xsd:string">1234567890abcdef1234567890abcdef</soapId>
+        <returnString xsi:type="xsd:string">OK</returnString>
+      </return>
+      <paymentMethod xmlns="" xsi:type="vin:PaymentMethod">
+        <VID xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_REFERENCE]</VID>
+        <type xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</type>
+        <creditCard xmlns="" xsi:type="vin:CreditCard">
+          <account xmlns="" xsi:type="xsd:string">[CARD_FIRST_SIX]XXXXXX[CARD_LAST_FOUR]</account>
+          <bin xmlns="" xsi:type="xsd:string">[CARD_FIRST_SIX]</bin>
+          <lastDigits xmlns="" xsi:type="xsd:string">[CARD_LAST_FOUR]</lastDigits>
+          <accountLength xmlns="" xsi:type="xsd:int">16</accountLength>
+          <expirationDate xmlns="" xsi:type="xsd:string">[EXPIRY_YEAR][EXPIRY_MONTH]</expirationDate>
+          <extendedCardAttributes xmlns="" xsi:type="vin:ExtendedCardAttributes">
+            <CommercialCard xmlns="" xsi:type="xsd:int">0</CommercialCard>
+            <SignatureDebitCard xmlns="" xsi:type="xsd:int">0</SignatureDebitCard>
+            <PINlessDebitCard xmlns="" xsi:type="xsd:int">0</PINlessDebitCard>
+            <PrepaidCard xmlns="" xsi:type="xsd:int">0</PrepaidCard>
+            <PayrollCard xmlns="" xsi:type="xsd:int">0</PayrollCard>
+            <HealthcareCard xmlns="" xsi:type="xsd:int">0</HealthcareCard>
+            <CountryOfIssuance xmlns="" xsi:type="xsd:string">USA</CountryOfIssuance>
+            <DurbinRegulated xmlns="" xsi:type="xsd:int">0</DurbinRegulated>
+            <Affluent xmlns="" xsi:type="xsd:int">0</Affluent>
+          </extendedCardAttributes>
+          <VID xmlns="" xsi:type="xsd:string">0123456789fedcba0123456789fedcba</VID>
+        </creditCard>
+        <merchantPaymentMethodId xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_ID]</merchantPaymentMethodId>
+        <sortOrder xmlns="" xsi:type="xsd:int">0</sortOrder>
+        <active xmlns="" xsi:type="xsd:boolean">1</active>
+      </paymentMethod>
+      <created xmlns="" xsi:type="xsd:boolean">0</created>
+      <validated xmlns="" xsi:type="xsd:boolean">1</validated>
+      <score xmlns="" xsi:type="xsd:int">-1</score>
+      <authStatus xmlns="" xsi:type="vin:TransactionStatus">
+        <status xmlns="" xsi:type="vin:TransactionStatusType">AuthorizedForValidation</status>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-12-07T06:36:09-08:00</timestamp>
+        <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
+        <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
+          <authCode xmlns="" xsi:type="xsd:string">[AUTHORIZATION_CODE]</authCode>
+          <avsCode xmlns="" xsi:type="xsd:string">[AVS_CODE]</avsCode>
+          <extendedCardAttributes xmlns="" xsi:type="vin:ExtendedCardAttributes">
+            <CommercialCard xmlns="" xsi:type="xsd:int">0</CommercialCard>
+            <SignatureDebitCard xmlns="" xsi:type="xsd:int">0</SignatureDebitCard>
+            <PINlessDebitCard xmlns="" xsi:type="xsd:int">0</PINlessDebitCard>
+            <PrepaidCard xmlns="" xsi:type="xsd:int">0</PrepaidCard>
+            <PayrollCard xmlns="" xsi:type="xsd:int">0</PayrollCard>
+            <HealthcareCard xmlns="" xsi:type="xsd:int">0</HealthcareCard>
+            <CountryOfIssuance xmlns="" xsi:type="xsd:string">[COUNTRY]</CountryOfIssuance>
+            <DurbinRegulated xmlns="" xsi:type="xsd:int">0</DurbinRegulated>
+            <Affluent xmlns="" xsi:type="xsd:int">0</Affluent>
+          </extendedCardAttributes>
+        </creditCardStatus>
+        <vinAVS xmlns="" xsi:type="vin:AVSMatchType">PartialMatch</vinAVS>
+      </authStatus>
+    </updateResponse>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
Just creates a payment method without attaching it to the customer object.

Includes better handling of multiple success codes that can come up when adding payment methods.