### PR TITLE
Add subscription billing state

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -339,8 +339,9 @@ class Response extends AbstractResponse
      */
     public function getSubscriptionStatus()
     {
-        if (isset($this->data->autobill)) {
-            return $this->data->autobill->status;
+        $subscription = $this->getSubscription();
+        if ($subscription) {
+            return $subscription->getStatus();
         }
         return null;
     }
@@ -352,8 +353,9 @@ class Response extends AbstractResponse
      */
     public function getSubscriptionBillingState()
     {
-        if (isset($this->data->autobill)) {
-            return $this->data->autobill->billingState;
+        $subscription = $this->getSubscription();
+        if ($subscription) {
+            return $subscription->getBillingState();
         }
         return null;
     }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -346,6 +346,19 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Get the billing state of the subscription.
+     *
+     * @return string|null
+     */
+    public function getSubscriptionBillingState()
+    {
+        if (isset($this->data->autobill)) {
+            return $this->data->autobill->billingState;
+        }
+        return null;
+    }
+
+    /**
      * Get the billing day of the subscription.
      *
      * @return int|null

--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -295,6 +295,7 @@ class ObjectHelper
             'paymentMethodReference' => isset($paymentMethod) ? $paymentMethod->getReference() : null,
             'ip' => isset($object->sourceIp) ? $object->sourceIp : null,
             'status' => isset($object->status) ? $object->status : null,
+            'billingState' => isset($object->billingState) ? $object->billingState : null,
             'startTime' => isset($object->startTimestamp) ? $object->startTimestamp : null,
             'endTime' => isset($object->endTimestamp) ? $object->endTimestamp : null,
             'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -489,6 +489,27 @@ class Subscription
     }
 
     /**
+     * Get the billing state
+     *
+     * @return null|string
+     */
+    public function getBillingState()
+    {
+        return $this->getParameter('billingState');
+    }
+
+    /**
+     * Set the billing state
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setBillingState($value)
+    {
+        return $this->setParameter('billingState', $value);
+    }
+
+    /**
      * Get the billing day (day of the month when subscription was charge) of the subscription.
      *
      * @return int|null

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -203,8 +203,8 @@ class DataFaker
     public function subscriptionStatus()
     {
         $statuses = array('Active', 'Suspended', 'Cancelled');
-        shuffle($statuses);
-        return current($statuses);
+        $index = $this->intBetween(0, 2);
+        return $statuses[$index];
     }
 
     /**
@@ -222,8 +222,8 @@ class DataFaker
             'Unusable Payment Method',
             'Billing Completed'
         );
-        shuffle($billingState);
-        return current($billingState);
+        $index = $this->intBetween(0, 5);
+        return $billingState[$index];
     }
 
     /**

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -195,7 +195,7 @@ class DataFaker
         return $result;
     }
 
-     /**
+    /**
      * Return a subscription status
      *
      * @return string
@@ -205,6 +205,25 @@ class DataFaker
         $statuses = array('Active', 'Suspended', 'Cancelled');
         shuffle($statuses);
         return current($statuses);
+    }
+
+    /**
+     * Return a subscription billing state
+     *
+     * @return string
+     */
+    public function subscriptionBillingState()
+    {
+        $billingState = array(
+            'Unbilled',
+            'Good Standing',
+            'Free/Trial',
+            'In Retry',
+            'Unusable Payment Method',
+            'Billing Completed'
+        );
+        shuffle($billingState);
+        return current($billingState);
     }
 
     /**

--- a/tests/Message/CreatePayPalSubscriptionRequestTest.php
+++ b/tests/Message/CreatePayPalSubscriptionRequestTest.php
@@ -33,6 +33,8 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
         $this->startTime = $this->faker->timestamp();
         $this->paymentMethodId = $this->faker->paymentMethodId();
         $this->attributes = $this->faker->attributesAsArray();
+        $this->subscriptionStatus = $this->faker->subscriptionStatus();
+        $this->subscriptionBillingState = $this->faker->subscriptionBillingState();
         $this->returnUrl = $this->faker->url();
         $this->cancelUrl = $this->faker->url();
         $this->card = array(
@@ -384,7 +386,9 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
             'RETURN_URL' => $this->returnUrl,
             'CANCEL_URL' => $this->cancelUrl,
             'PAYPAL_TOKEN' => $this->payPalToken,
-            'RISK_SCORE' => $this->riskScore
+            'RISK_SCORE' => $this->riskScore,
+            'STATUS' => $this->subscriptionStatus,
+            'BILLING_STATE' => $this->subscriptionBillingState
         ));
 
         $response = $this->request->send();
@@ -395,6 +399,8 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->subscriptionId, $response->getSubscriptionId());
         $this->assertSame($this->subscriptionReference, $response->getSubscriptionReference());
+        $this->assertSame($this->subscriptionStatus, $response->getSubscriptionStatus());
+        $this->assertSame($this->subscriptionBillingState, $response->getSubscriptionBillingState());
         $this->assertSame('https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&token=' . $this->payPalToken, $response->getRedirectUrl());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -36,6 +36,8 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->minChargebackProbability = $this->faker->chargebackProbability();
         $this->name = $this->faker->name();
         $this->email = $this->faker->email();
+        $this->subscriptionStatus = $this->faker->subscriptionStatus();
+        $this->subscriptionBillingState = $this->faker->subscriptionBillingState();
         $this->attributes = $this->faker->attributesAsArray();
 
         $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -378,7 +380,9 @@ class CreateSubscriptionRequestTest extends SoapTestCase
             'STATEMENT_DESCRIPTOR' => $this->statementDescriptor,
             'IP_ADDRESS' => $this->ip,
             'RISK_SCORE' => $this->riskScore,
-            'BILLING_DAY' => $this->billingDay
+            'BILLING_DAY' => $this->billingDay,
+            'STATUS' => $this->subscriptionStatus,
+            'BILLING_STATE' => $this->subscriptionBillingState
         ));
 
         $response = $this->request->send();
@@ -389,7 +393,8 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->subscriptionId, $response->getSubscriptionId());
         $this->assertSame($this->subscriptionReference, $response->getSubscriptionReference());
-        $this->assertSame('Pending Activation', $response->getSubscriptionStatus());
+        $this->assertSame($this->subscriptionStatus, $response->getSubscriptionStatus());
+        $this->assertSame($this->subscriptionBillingState, $response->getSubscriptionBillingState());
         $this->assertSame($this->riskScore, $response->getRiskScore());
         $this->assertSame($this->billingDay, $response->getBillingDay());
 

--- a/tests/Message/FetchSubscriptionRequestTest.php
+++ b/tests/Message/FetchSubscriptionRequestTest.php
@@ -39,6 +39,7 @@ class FetchSubscriptionRequestTest extends SoapTestCase
         $this->startTime = $this->faker->timestamp();
         $this->endTime = $this->faker->timestamp();
         $this->subscriptionStatus = $this->faker->subscriptionStatus();
+        $this->subscriptionBillingState = $this->faker->subscriptionBillingState();
     }
 
     /**
@@ -122,7 +123,8 @@ class FetchSubscriptionRequestTest extends SoapTestCase
             'IP_ADDRESS' => $this->ipAddress,
             'START_TIMESTAMP' => $this->startTime,
             'END_TIMESTAMP' => $this->endTime,
-            'STATUS' => $this->subscriptionStatus
+            'STATUS' => $this->subscriptionStatus,
+            'BILLING_STATE' => $this->subscriptionBillingState
         ));
 
         $response = $this->request->send();
@@ -141,6 +143,7 @@ class FetchSubscriptionRequestTest extends SoapTestCase
         $this->assertSame($this->startTime, $subscription->getStartTime());
         $this->assertSame($this->endTime, $subscription->getEndTime());
         $this->assertSame($this->subscriptionStatus, $subscription->getStatus());
+        $this->assertSame($this->subscriptionBillingState, $subscription->getBillingState());
         $customer = $subscription->getCustomer();
         $this->assertSame($this->customerId, $subscription->getCustomerId());
         $this->assertSame($this->customerId, $customer->getId());

--- a/tests/Mock/CreatePayPalSubscriptionSuccess.xml
+++ b/tests/Mock/CreatePayPalSubscriptionSuccess.xml
@@ -65,8 +65,8 @@
           <active xmlns="" xsi:type="xsd:boolean">1</active>
         </paymentMethod>
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
-        <status xmlns="" xsi:type="vin:AutoBillStatus">Pending Activation</status>
-        <billingState xmlns="" xsi:type="vin:BillingState">Unbilled</billingState>
+        <status xmlns="" xsi:type="vin:AutoBillStatus">[STATUS]</status>
+        <billingState xmlns="" xsi:type="vin:BillingState">[BILLING_STATE]</billingState>
         <startTimestamp xmlns="" xsi:type="xsd:dateTime">2016-12-01T12:00:00-08:00</startTimestamp>
         <items xmlns="" xsi:type="vin:AutoBillItem">
           <VID xmlns="" xsi:type="xsd:string">01234567899876543210abcdeffedcba</VID>

--- a/tests/Mock/CreateSubscriptionSuccess.xml
+++ b/tests/Mock/CreateSubscriptionSuccess.xml
@@ -73,8 +73,8 @@
           <active xmlns="" xsi:type="xsd:boolean">1</active>
         </paymentMethod>
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
-        <status xmlns="" xsi:type="vin:AutoBillStatus">Pending Activation</status>
-        <billingState xmlns="" xsi:type="vin:BillingState">Unbilled</billingState>
+        <status xmlns="" xsi:type="vin:AutoBillStatus">[STATUS]</status>
+        <billingState xmlns="" xsi:type="vin:BillingState">[BILLING_STATE]</billingState>
         <startTimestamp xmlns="" xsi:type="xsd:dateTime">[START_TIME]</startTimestamp>
         <endTimestamp xmlns="" xsi:type="xsd:dateTime">2017-12-01T00:00:00-08:00</endTimestamp>
         <items xmlns="" xsi:type="vin:AutoBillItem">

--- a/tests/Mock/FetchSubscriptionSuccess.xml
+++ b/tests/Mock/FetchSubscriptionSuccess.xml
@@ -70,7 +70,7 @@
         </paymentMethod>
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
         <status xmlns="" xsi:type="vin:AutoBillStatus">[STATUS]</status>
-        <billingState xmlns="" xsi:type="vin:BillingState">Billing Completed</billingState>
+        <billingState xmlns="" xsi:type="vin:BillingState">[BILLING_STATE]</billingState>
         <startTimestamp xmlns="" xsi:type="xsd:dateTime">[START_TIMESTAMP]</startTimestamp>
         <endTimestamp xmlns="" xsi:type="xsd:dateTime">[END_TIMESTAMP]</endTimestamp>
         <items xmlns="" xsi:type="vin:AutoBillItem">


### PR DESCRIPTION
Subscription billing state and status will help decide subscription's billing status. For example subscription status is active and billing state is "In Retry" it means subscription is active but in grace period.

cc @nickyr 