### PR TITLE
Use refund object instead of stdClass for refund response

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -93,6 +93,7 @@ use Omnipay\Vindicia\VindiciaRefundItemBag;
  *   if ($refundResponse->isSuccessful()) {
  *       echo "Refund id: " . $refundResponse->getRefundId() . PHP_EOL;
  *       echo "Refund reference: " . $refundResponse->getRefundReference() . PHP_EOL;
+ *       echo "Refund amount: " . $refundResponse->getRefund()->getAmount() . PHP_EOL;
  *   } else {
  *       // error handling
  *   }

--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -34,8 +34,9 @@ class RefundResponse extends Response
      */
     public function getRefundReference()
     {
-        if (isset($this->data->refunds[0]->VID)) {
-            return $this->data->refunds[0]->VID;
+        $refund = $this->getRefund();
+        if ($refund) {
+            return $refund->getReference();
         }
         return null;
     }
@@ -49,8 +50,9 @@ class RefundResponse extends Response
      */
     public function getRefundId()
     {
-        if (isset($this->data->refunds[0]->merchantRefundId)) {
-            return $this->data->refunds[0]->merchantRefundId;
+        $refund = $this->getRefund();
+        if ($refund) {
+            return $refund->getId();
         }
         return null;
     }
@@ -63,7 +65,7 @@ class RefundResponse extends Response
     public function getRefund()
     {
         if (isset($this->data->refunds[0])) {
-            return $this->data->refunds[0];
+            return $this->objectHelper->buildRefund($this->data->refunds[0]);
         }
         return null;
     }

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -340,9 +340,14 @@ class RefundRequestTest extends SoapTestCase
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isPending());
         $this->assertSame('OK', $response->getMessage());
+        $refund = $response->getRefund();
+        $this->assertNotNull($refund);
         $this->assertSame($this->refundId, $response->getRefundId());
+        $this->assertSame($this->refundId, $refund->getId());
         $this->assertSame($this->refundReference, $response->getRefundReference());
-        $this->assertNotNull($response->getRefund());
+        $this->assertSame($this->refundReference, $refund->getReference());
+        $this->assertSame($this->refundAmount, $refund->getAmount());
+        $this->assertSame($this->note, $refund->getNote());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Refund.wsdl', $this->getLastEndpoint());
     }


### PR DESCRIPTION
Lets you can grab a `Refund` object from a refund response with `getRefund` instead of just getting a `stdClass`