### PR TITLE
Include object names in id/reference param names

### DIFF
--- a/src/Chargeback.php
+++ b/src/Chargeback.php
@@ -72,10 +72,9 @@ class Chargeback
      *
      * @return null|string
      */
-
-    public function getId()
+    public function getChargebackId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('chargebackId');
     }
 
     /**
@@ -84,9 +83,9 @@ class Chargeback
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setChargebackId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('chargebackId', $value);
     }
 
     /**
@@ -94,9 +93,9 @@ class Chargeback
      *
      * @return null|string
      */
-    public function getReference()
+    public function getChargebackReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('chargebackReference');
     }
 
     /**
@@ -105,9 +104,55 @@ class Chargeback
      * @param string $value
      * @return static
      */
+    public function setChargebackReference($value)
+    {
+        return $this->setParameter('chargebackReference', $value);
+    }
+
+    /**
+     * Get the chargeback id (not supported by Vindicia)
+     *
+     * @return null|string
+     * @deprecated see getChargebackId
+     */
+    public function getId()
+    {
+        return $this->getChargebackId();
+    }
+
+    /**
+     * Set the chargeback id (not supported by Vindicia)
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setChargebackId
+     */
+    public function setId($value)
+    {
+        return $this->setChargebackId($value);
+    }
+
+    /**
+     * Get the chargeback reference
+     *
+     * @return null|string
+     * @deprecated see getChargebackReference
+     */
+    public function getReference()
+    {
+        return $this->getChargebackReference();
+    }
+
+    /**
+     * Set the chargeback reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setChargebackReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setChargebackReference($value);
     }
 
     /**

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -72,10 +72,9 @@ class Customer
      *
      * @return null|string
      */
-
-    public function getId()
+    public function getCustomerId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('customerId');
     }
 
     /**
@@ -84,9 +83,9 @@ class Customer
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setCustomerId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('customerId', $value);
     }
 
     /**
@@ -94,9 +93,9 @@ class Customer
      *
      * @return null|string
      */
-    public function getReference()
+    public function getCustomerReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('customerReference');
     }
 
     /**
@@ -105,9 +104,55 @@ class Customer
      * @param string $value
      * @return static
      */
+    public function setCustomerReference($value)
+    {
+        return $this->setParameter('customerReference', $value);
+    }
+
+    /**
+     * Get the customer id
+     *
+     * @return null|string
+     * @deprecated see getCustomerId
+     */
+    public function getId()
+    {
+        return $this->getCustomerId();
+    }
+
+    /**
+     * Set the customer id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setCustomerId
+     */
+    public function setId($value)
+    {
+        return $this->setCustomerId($value);
+    }
+
+    /**
+     * Get the customer reference
+     *
+     * @return null|string
+     * @deprecated see getCustomerReference
+     */
+    public function getReference()
+    {
+        return $this->getCustomerReference();
+    }
+
+    /**
+     * Set the customer reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setCustomerReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setCustomerReference($value);
     }
 
     /**

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -195,7 +195,7 @@ class Response extends AbstractResponse
     {
         $customer = $this->getCustomer();
         if ($customer) {
-            return $customer->getReference();
+            return $customer->getCustomerReference();
         }
         return null;
     }
@@ -210,7 +210,7 @@ class Response extends AbstractResponse
     {
         $customer = $this->getCustomer();
         if ($customer) {
-            return $customer->getId();
+            return $customer->getCustomerId();
         }
         return null;
     }
@@ -235,7 +235,7 @@ class Response extends AbstractResponse
     {
         $plan = $this->getPlan();
         if ($plan) {
-            return $plan->getReference();
+            return $plan->getPlanReference();
         }
         return null;
     }
@@ -249,7 +249,7 @@ class Response extends AbstractResponse
     {
         $plan = $this->getPlan();
         if ($plan) {
-            return $plan->getId();
+            return $plan->getPlanId();
         }
         return null;
     }
@@ -274,7 +274,7 @@ class Response extends AbstractResponse
     {
         $product = $this->getProduct();
         if ($product) {
-            return $product->getReference();
+            return $product->getProductReference();
         }
         return null;
     }
@@ -288,7 +288,7 @@ class Response extends AbstractResponse
     {
         $product = $this->getProduct();
         if ($product) {
-            return $product->getId();
+            return $product->getProductId();
         }
         return null;
     }
@@ -416,7 +416,7 @@ class Response extends AbstractResponse
     {
         $paymentMethod = $this->getPaymentMethod();
         if ($paymentMethod) {
-            return $paymentMethod->getId();
+            return $paymentMethod->getPaymentMethodId();
         }
 
         return null;
@@ -431,7 +431,7 @@ class Response extends AbstractResponse
     {
         $paymentMethod = $this->getPaymentMethod();
         if ($paymentMethod) {
-            return $paymentMethod->getReference();
+            return $paymentMethod->getPaymentMethodReference();
         }
 
         return null;

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -153,7 +153,7 @@ class Response extends AbstractResponse
     {
         $transaction = $this->getTransaction();
         if ($transaction) {
-            return $transaction->getReference();
+            return $transaction->getTransactionReference();
         }
         return null;
     }
@@ -170,7 +170,7 @@ class Response extends AbstractResponse
     {
         $transaction = $this->getTransaction();
         if ($transaction) {
-            return $transaction->getId();
+            return $transaction->getTransactionId();
         }
         return null;
     }
@@ -313,7 +313,7 @@ class Response extends AbstractResponse
     {
         $subscription = $this->getSubscription();
         if ($subscription) {
-            return $subscription->getReference();
+            return $subscription->getSubscriptionReference();
         }
         return null;
     }
@@ -327,7 +327,7 @@ class Response extends AbstractResponse
     {
         $subscription = $this->getSubscription();
         if ($subscription) {
-            return $subscription->getId();
+            return $subscription->getSubscriptionId();
         }
         return null;
     }

--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -51,16 +51,16 @@ class ObjectHelper
         }
 
         return new Transaction(array(
-            'id' => isset($object->merchantTransactionId) ? $object->merchantTransactionId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'transactionId' => isset($object->merchantTransactionId) ? $object->merchantTransactionId : null,
+            'transactionReference' => isset($object->VID) ? $object->VID : null,
             'currency' => isset($object->currency) ? $object->currency : null,
             'amount' => isset($object->amount) ? $object->amount : null,
             'customer' => $customer,
-            'customerId' => isset($customer) ? $customer->getId() : null,
-            'customerReference' => isset($customer) ? $customer->getReference() : null,
+            'customerId' => isset($customer) ? $customer->getCustomerId() : null,
+            'customerReference' => isset($customer) ? $customer->getCustomerReference() : null,
             'paymentMethod' => isset($paymentMethod) ? $paymentMethod : null,
-            'paymentMethodId' => isset($paymentMethod) ? $paymentMethod->getId() : null,
-            'paymentMethodReference' => isset($paymentMethod) ? $paymentMethod->getReference() : null,
+            'paymentMethodId' => isset($paymentMethod) ? $paymentMethod->getPaymentMethodId() : null,
+            'paymentMethodReference' => isset($paymentMethod) ? $paymentMethod->getPaymentMethodReference() : null,
             'items' => $items,
             'ip' => isset($object->sourceIp) ? $object->sourceIp : null,
             'authorizationCode' => isset($object->statusLog[0]->creditCardStatus->authCode)
@@ -90,8 +90,8 @@ class ObjectHelper
     public function buildChargeback(stdClass $object)
     {
         return new Chargeback(array(
-            'id' => null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'chargebackId' => null,
+            'chargebackReference' => isset($object->VID) ? $object->VID : null,
             'transactionId' => isset($object->merchantTransactionId) ? $object->merchantTransactionId : null,
             'transactionReference' => null,
             'transaction' => null,
@@ -123,8 +123,8 @@ class ObjectHelper
         }
 
         return new Customer(array(
-            'id' => isset($object->merchantAccountId) ? $object->merchantAccountId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'customerId' => isset($object->merchantAccountId) ? $object->merchantAccountId : null,
+            'customerReference' => isset($object->VID) ? $object->VID : null,
             'name' => isset($object->name) ? $object->name : null,
             'email' => isset($object->emailAddress) ? $object->emailAddress : null,
             'taxExemptions' => isset($taxExemptions) ? $taxExemptions : null,
@@ -153,8 +153,8 @@ class ObjectHelper
         }
 
         return new PaymentMethod(array(
-            'id' => isset($object->merchantPaymentMethodId) ? $object->merchantPaymentMethodId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'paymentMethodId' => isset($object->merchantPaymentMethodId) ? $object->merchantPaymentMethodId : null,
+            'paymentMethodReference' => isset($object->VID) ? $object->VID : null,
             // NonStrippingCreditCard won't remove the X's that Vindicia masks with
             'card' => new NonStrippingCreditCard(array(
                 'name' => isset($object->accountHolderName) ? $object->accountHolderName : null,
@@ -183,8 +183,8 @@ class ObjectHelper
     public function buildPlan(stdClass $object)
     {
         return new Plan(array(
-            'id' => isset($object->merchantBillingPlanId) ? $object->merchantBillingPlanId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'planId' => isset($object->merchantBillingPlanId) ? $object->merchantBillingPlanId : null,
+            'planReference' => isset($object->VID) ? $object->VID : null,
             'interval' => isset($object->periods[0]->type) ? strtolower($object->periods[0]->type) : null,
             'intervalCount' => isset($object->periods[0]->quantity) ? strtolower($object->periods[0]->quantity) : null,
             'taxClassification' => isset($object->taxClassification) ? $object->taxClassification : null,
@@ -201,11 +201,11 @@ class ObjectHelper
         $plan = isset($object->defaultBillingPlan) ? $this->buildPlan($object->defaultBillingPlan) : null;
 
         return new Product(array(
-            'id' => isset($object->merchantProductId) ? $object->merchantProductId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'productId' => isset($object->merchantProductId) ? $object->merchantProductId : null,
+            'productReference' => isset($object->VID) ? $object->VID : null,
             'plan' => isset($plan) ? $plan : null,
-            'planId' => isset($plan) ? $plan->getId() : null,
-            'planReference' => isset($plan) ? $plan->getReference() : null,
+            'planId' => isset($plan) ? $plan->getPlanId() : null,
+            'planReference' => isset($plan) ? $plan->getPlanReference() : null,
             'taxClassification' => isset($object->taxClassification) ? $object->taxClassification : null,
             'prices' => isset($object->prices) ? $this->buildPrices($object->prices) : null,
             'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null
@@ -235,8 +235,8 @@ class ObjectHelper
         }
 
         return new Refund(array(
-            'id' => isset($object->merchantRefundId) ? $object->merchantRefundId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'refundId' => isset($object->merchantRefundId) ? $object->merchantRefundId : null,
+            'refundReference' => isset($object->VID) ? $object->VID : null,
             'currency' => isset($object->currency) ? $object->currency : null,
             'amount' => isset($object->amount) ? $object->amount : null,
             'note' => isset($object->note) ? $object->note : null,
@@ -264,7 +264,7 @@ class ObjectHelper
             $items = array();
             foreach ($object->items as $item) {
                 $items[] = new VindiciaItem(array(
-                    'reference' => isset($item->VID) ? $item->VID : null,
+                    'itemReference' => isset($item->VID) ? $item->VID : null,
                     'sku' => isset($item->product->merchantProductId) ? $item->product->merchantProductId : null,
                     'index' => isset($item->index) ? $item->index : null,
                     'price' => isset($item->price) ? $item->price : null,
@@ -277,22 +277,22 @@ class ObjectHelper
         }
 
         return new Subscription(array(
-            'id' => isset($object->merchantAutoBillId) ? $object->merchantAutoBillId : null,
-            'reference' => isset($object->VID) ? $object->VID : null,
+            'subscriptionId' => isset($object->merchantAutoBillId) ? $object->merchantAutoBillId : null,
+            'subscriptionReference' => isset($object->VID) ? $object->VID : null,
             'currency' => isset($object->currency) ? $object->currency : null,
             'customer' => isset($customer) ? $customer : null,
-            'customerId' => isset($customer) ? $customer->getId() : null,
-            'customerReference' => isset($customer) ? $customer->getReference() : null,
+            'customerId' => isset($customer) ? $customer->getCustomerId() : null,
+            'customerReference' => isset($customer) ? $customer->getCustomerReference() : null,
             'items' => $items,
             'product' => isset($product) ? $product : null,
-            'productId' => isset($product) ? $product->getId() : null,
-            'productReference' => isset($product) ? $product->getReference() : null,
+            'productId' => isset($product) ? $product->getProductId() : null,
+            'productReference' => isset($product) ? $product->getProductReference() : null,
             'plan' => isset($plan) ? $plan : null,
-            'planId' => isset($plan) ? $plan->getId() : null,
-            'planReference' => isset($plan) ? $plan->getReference() : null,
+            'planId' => isset($plan) ? $plan->getPlanId() : null,
+            'planReference' => isset($plan) ? $plan->getPlanReference() : null,
             'paymentMethod' => isset($paymentMethod) ? $paymentMethod : null,
-            'paymentMethodId' => isset($paymentMethod) ? $paymentMethod->getId() : null,
-            'paymentMethodReference' => isset($paymentMethod) ? $paymentMethod->getReference() : null,
+            'paymentMethodId' => isset($paymentMethod) ? $paymentMethod->getPaymentMethodId() : null,
+            'paymentMethodReference' => isset($paymentMethod) ? $paymentMethod->getPaymentMethodReference() : null,
             'ip' => isset($object->sourceIp) ? $object->sourceIp : null,
             'status' => isset($object->status) ? $object->status : null,
             'billingState' => isset($object->billingState) ? $object->billingState : null,

--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -242,8 +242,8 @@ class ObjectHelper
             'note' => isset($object->note) ? $object->note : null,
             'time' => isset($object->timestamp) ? $object->timestamp : null,
             'transaction' => isset($transaction) ? $transaction : null,
-            'transactionId' => isset($transaction) ? $transaction->getId() : null,
-            'transactionReference' => isset($transaction) ? $transaction->getReference() : null,
+            'transactionId' => isset($transaction) ? $transaction->getTransactionId() : null,
+            'transactionReference' => isset($transaction) ? $transaction->getTransactionReference() : null,
             'items' => isset($items) ? $items : null,
             'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null
         ));

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -69,46 +69,91 @@ class PaymentMethod
     }
 
     /**
-     * Get the payment method id
+     * Get the paymentMethod id
      *
      * @return null|string
      */
-
-    public function getId()
+    public function getPaymentMethodId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('paymentMethodId');
     }
 
     /**
-     * Set the payment method id
+     * Set the paymentMethod id
      *
      * @param string $value
      * @return static
+     */
+    public function setPaymentMethodId($value)
+    {
+        return $this->setParameter('paymentMethodId', $value);
+    }
+
+    /**
+     * Get the paymentMethod reference
+     *
+     * @return null|string
+     */
+    public function getPaymentMethodReference()
+    {
+        return $this->getParameter('paymentMethodReference');
+    }
+
+    /**
+     * Set the paymentMethod reference
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setPaymentMethodReference($value)
+    {
+        return $this->setParameter('paymentMethodReference', $value);
+    }
+
+    /**
+     * Get the paymentMethod id
+     *
+     * @return null|string
+     * @deprecated see getPaymentMethodId
+     */
+    public function getId()
+    {
+        return $this->getPaymentMethodId();
+    }
+
+    /**
+     * Set the paymentMethod id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setPaymentMethodId
      */
     public function setId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setPaymentMethodId($value);
     }
 
     /**
-     * Get the payment method reference
+     * Get the paymentMethod reference
      *
      * @return null|string
+     * @deprecated see getPaymentMethodReference
      */
     public function getReference()
     {
-        return $this->getParameter('reference');
+        return $this->getPaymentMethodReference();
     }
 
     /**
-     * Set the payment method reference
+     * Set the paymentMethod reference
      *
      * @param string $value
      * @return static
+     * @deprecated see setPaymentMethodReference
      */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setPaymentMethodReference($value);
     }
 
     /**

--- a/src/Plan.php
+++ b/src/Plan.php
@@ -72,9 +72,9 @@ class Plan
      *
      * @return null|string
      */
-    public function getId()
+    public function getPlanId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('planId');
     }
 
     /**
@@ -83,9 +83,9 @@ class Plan
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setPlanId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('planId', $value);
     }
 
     /**
@@ -93,9 +93,9 @@ class Plan
      *
      * @return null|string
      */
-    public function getReference()
+    public function getPlanReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('planReference');
     }
 
     /**
@@ -104,9 +104,55 @@ class Plan
      * @param string $value
      * @return static
      */
+    public function setPlanReference($value)
+    {
+        return $this->setParameter('planReference', $value);
+    }
+
+    /**
+     * Get the plan id
+     *
+     * @return null|string
+     * @deprecated see getPlanId
+     */
+    public function getId()
+    {
+        return $this->getPlanId();
+    }
+
+    /**
+     * Set the plan id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setPlanId
+     */
+    public function setId($value)
+    {
+        return $this->setPlanId($value);
+    }
+
+    /**
+     * Get the plan reference
+     *
+     * @return null|string
+     * @deprecated see getPlanReference
+     */
+    public function getReference()
+    {
+        return $this->getPlanReference();
+    }
+
+    /**
+     * Set the plan reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setPlanReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setPlanReference($value);
     }
 
     /**

--- a/src/Product.php
+++ b/src/Product.php
@@ -72,9 +72,9 @@ class Product
      *
      * @return null|string
      */
-    public function getId()
+    public function getProductId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('productId');
     }
 
     /**
@@ -83,9 +83,9 @@ class Product
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setProductId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('productId', $value);
     }
 
     /**
@@ -93,9 +93,9 @@ class Product
      *
      * @return null|string
      */
-    public function getReference()
+    public function getProductReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('productReference');
     }
 
     /**
@@ -104,9 +104,55 @@ class Product
      * @param string $value
      * @return static
      */
+    public function setProductReference($value)
+    {
+        return $this->setParameter('productReference', $value);
+    }
+
+    /**
+     * Get the product id
+     *
+     * @return null|string
+     * @deprecated see getProductId
+     */
+    public function getId()
+    {
+        return $this->getProductId();
+    }
+
+    /**
+     * Set the product id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setProductId
+     */
+    public function setId($value)
+    {
+        return $this->setProductId($value);
+    }
+
+    /**
+     * Get the product reference
+     *
+     * @return null|string
+     * @deprecated see getProductReference
+     */
+    public function getReference()
+    {
+        return $this->getProductReference();
+    }
+
+    /**
+     * Set the product reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setProductReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setProductReference($value);
     }
 
     /**

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -72,9 +72,9 @@ class Refund
      *
      * @return null|string
      */
-    public function getId()
+    public function getRefundId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('refundId');
     }
 
     /**
@@ -83,9 +83,9 @@ class Refund
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setRefundId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('refundId', $value);
     }
 
     /**
@@ -93,9 +93,9 @@ class Refund
      *
      * @return null|string
      */
-    public function getReference()
+    public function getRefundReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('refundReference');
     }
 
     /**
@@ -104,9 +104,55 @@ class Refund
      * @param string $value
      * @return static
      */
+    public function setRefundReference($value)
+    {
+        return $this->setParameter('refundReference', $value);
+    }
+
+    /**
+     * Get the refund id
+     *
+     * @return null|string
+     * @deprecated see getRefundId
+     */
+    public function getId()
+    {
+        return $this->getRefundId();
+    }
+
+    /**
+     * Set the refund id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setRefundId
+     */
+    public function setId($value)
+    {
+        return $this->setRefundId($value);
+    }
+
+    /**
+     * Get the refund reference
+     *
+     * @return null|string
+     * @deprecated see getRefundReference
+     */
+    public function getReference()
+    {
+        return $this->getRefundReference();
+    }
+
+    /**
+     * Set the refund reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setRefundReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setRefundReference($value);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -72,9 +72,9 @@ class Subscription
      *
      * @return null|string
      */
-    public function getId()
+    public function getSubscriptionId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('subscriptionId');
     }
 
     /**
@@ -83,9 +83,9 @@ class Subscription
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setSubscriptionId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('subscriptionId', $value);
     }
 
     /**
@@ -93,9 +93,9 @@ class Subscription
      *
      * @return null|string
      */
-    public function getReference()
+    public function getSubscriptionReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('subscriptionReference');
     }
 
     /**
@@ -104,9 +104,55 @@ class Subscription
      * @param string $value
      * @return static
      */
+    public function setSubscriptionReference($value)
+    {
+        return $this->setParameter('subscriptionReference', $value);
+    }
+
+    /**
+     * Get the subscription id
+     *
+     * @return null|string
+     * @deprecated see getSubscriptionId
+     */
+    public function getId()
+    {
+        return $this->getSubscriptionId();
+    }
+
+    /**
+     * Set the subscription id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setSubscriptionId
+     */
+    public function setId($value)
+    {
+        return $this->setSubscriptionId($value);
+    }
+
+    /**
+     * Get the subscription reference
+     *
+     * @return null|string
+     * @deprecated see getSubscriptionReference
+     */
+    public function getReference()
+    {
+        return $this->getSubscriptionReference();
+    }
+
+    /**
+     * Set the subscription reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setSubscriptionReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setSubscriptionReference($value);
     }
 
     /**

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -72,9 +72,9 @@ class Transaction
      *
      * @return null|string
      */
-    public function getId()
+    public function getTransactionId()
     {
-        return $this->getParameter('id');
+        return $this->getParameter('transactionId');
     }
 
     /**
@@ -83,9 +83,9 @@ class Transaction
      * @param string $value
      * @return static
      */
-    public function setId($value)
+    public function setTransactionId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('transactionId', $value);
     }
 
     /**
@@ -93,9 +93,9 @@ class Transaction
      *
      * @return null|string
      */
-    public function getReference()
+    public function getTransactionReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('transactionReference');
     }
 
     /**
@@ -104,9 +104,55 @@ class Transaction
      * @param string $value
      * @return static
      */
+    public function setTransactionReference($value)
+    {
+        return $this->setParameter('transactionReference', $value);
+    }
+
+    /**
+     * Get the transaction id
+     *
+     * @return null|string
+     * @deprecated see getTransactionId
+     */
+    public function getId()
+    {
+        return $this->getTransactionId();
+    }
+
+    /**
+     * Set the transaction id
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setTransactionId
+     */
+    public function setId($value)
+    {
+        return $this->setTransactionId($value);
+    }
+
+    /**
+     * Get the transaction reference
+     *
+     * @return null|string
+     * @deprecated see getTransactionReference
+     */
+    public function getReference()
+    {
+        return $this->getTransactionReference();
+    }
+
+    /**
+     * Set the transaction reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setTransactionReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setTransactionReference($value);
     }
 
     /**
@@ -458,7 +504,7 @@ class Transaction
     /**
      * Set the status log
      *
-     * @param string $value
+     * @param array<TransactionStatus> $value
      * @return static
      */
     public function setStatusLog($value)

--- a/src/VindiciaItem.php
+++ b/src/VindiciaItem.php
@@ -12,15 +12,14 @@ use Omnipay\Vindicia\Exception\InvalidItemException;
  */
 class VindiciaItem extends Item
 {
-
     /**
      * Get the item reference
      *
      * @return null|string
      */
-    public function getReference()
+    public function getItemReference()
     {
-        return $this->getParameter('reference');
+        return $this->getParameter('itemReference');
     }
 
     /**
@@ -29,9 +28,32 @@ class VindiciaItem extends Item
      * @param string $value
      * @return static
      */
+    public function setItemReference($value)
+    {
+        return $this->setParameter('itemReference', $value);
+    }
+
+    /**
+     * Get the item reference
+     *
+     * @return null|string
+     * @deprecated see getItemReference
+     */
+    public function getReference()
+    {
+        return $this->getItemReference();
+    }
+
+    /**
+     * Set the item reference
+     *
+     * @param string $value
+     * @return static
+     * @deprecated see setItemReference
+     */
     public function setReference($value)
     {
-        return $this->setParameter('reference', $value);
+        return $this->setItemReference($value);
     }
 
     /**

--- a/tests/ChargebackTest.php
+++ b/tests/ChargebackTest.php
@@ -14,8 +14,8 @@ class ChargebackTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->chargeback = new Chargeback();
-        $this->id = $this->faker->chargebackId();
-        $this->reference = $this->faker->chargebackReference();
+        $this->chargebackId = $this->faker->chargebackId();
+        $this->chargebackReference = $this->faker->chargebackReference();
     }
 
     /**
@@ -24,11 +24,11 @@ class ChargebackTest extends TestCase
     public function testConstructWithParams()
     {
         $chargeback = new Chargeback(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'chargebackId' => $this->chargebackId,
+            'chargebackReference' => $this->chargebackReference
         ));
-        $this->assertSame($this->id, $chargeback->getId());
-        $this->assertSame($this->reference, $chargeback->getReference());
+        $this->assertSame($this->chargebackId, $chargeback->getChargebackId());
+        $this->assertSame($this->chargebackReference, $chargeback->getChargebackReference());
     }
 
     /**
@@ -37,11 +37,11 @@ class ChargebackTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->chargeback, $this->chargeback->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'chargebackId' => $this->chargebackId,
+            'chargebackReference' => $this->chargebackReference
         )));
-        $this->assertSame($this->id, $this->chargeback->getId());
-        $this->assertSame($this->reference, $this->chargeback->getReference());
+        $this->assertSame($this->chargebackId, $this->chargeback->getChargebackId());
+        $this->assertSame($this->chargebackReference, $this->chargeback->getChargebackReference());
     }
 
     /**
@@ -49,26 +49,46 @@ class ChargebackTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->chargeback, $this->chargeback->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->chargeback->getParameters());
+        $this->assertSame($this->chargeback, $this->chargeback->setChargebackId($this->chargebackId)->setChargebackReference($this->chargebackReference));
+        $this->assertSame(array('chargebackId' => $this->chargebackId, 'chargebackReference' => $this->chargebackReference), $this->chargeback->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testChargebackId()
+    {
+        $this->assertSame($this->chargeback, $this->chargeback->setChargebackId($this->chargebackId));
+        $this->assertSame($this->chargebackId, $this->chargeback->getChargebackId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testChargebackReference()
+    {
+        $this->assertSame($this->chargeback, $this->chargeback->setChargebackReference($this->chargebackReference));
+        $this->assertSame($this->chargebackReference, $this->chargeback->getChargebackReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->chargeback, $this->chargeback->setId($this->id));
-        $this->assertSame($this->id, $this->chargeback->getId());
+        $this->assertSame($this->chargeback, $this->chargeback->setId($this->chargebackId));
+        $this->assertSame($this->chargebackId, $this->chargeback->getId());
     }
 
     /**
      * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testReference()
     {
-        $this->assertSame($this->chargeback, $this->chargeback->setReference($this->reference));
-        $this->assertSame($this->reference, $this->chargeback->getReference());
+        $this->assertSame($this->chargeback, $this->chargeback->setReference($this->chargebackReference));
+        $this->assertSame($this->chargebackReference, $this->chargeback->getReference());
     }
 
     /**

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -14,8 +14,8 @@ class CustomerTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->customer = new Customer();
-        $this->id = $this->faker->customerId();
-        $this->reference = $this->faker->customerReference();
+        $this->customerId = $this->faker->customerId();
+        $this->customerReference = $this->faker->customerReference();
     }
 
     /**
@@ -24,11 +24,11 @@ class CustomerTest extends TestCase
     public function testConstructWithParams()
     {
         $customer = new Customer(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'customerId' => $this->customerId,
+            'customerReference' => $this->customerReference
         ));
-        $this->assertSame($this->id, $customer->getId());
-        $this->assertSame($this->reference, $customer->getReference());
+        $this->assertSame($this->customerId, $customer->getCustomerId());
+        $this->assertSame($this->customerReference, $customer->getCustomerReference());
     }
 
     /**
@@ -37,11 +37,11 @@ class CustomerTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->customer, $this->customer->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'customerId' => $this->customerId,
+            'customerReference' => $this->customerReference
         )));
-        $this->assertSame($this->id, $this->customer->getId());
-        $this->assertSame($this->reference, $this->customer->getReference());
+        $this->assertSame($this->customerId, $this->customer->getCustomerId());
+        $this->assertSame($this->customerReference, $this->customer->getCustomerReference());
     }
 
     /**
@@ -49,26 +49,46 @@ class CustomerTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->customer, $this->customer->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->customer->getParameters());
+        $this->assertSame($this->customer, $this->customer->setCustomerId($this->customerId)->setCustomerReference($this->customerReference));
+        $this->assertSame(array('customerId' => $this->customerId, 'customerReference' => $this->customerReference), $this->customer->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testCustomerId()
+    {
+        $this->assertSame($this->customer, $this->customer->setCustomerId($this->customerId));
+        $this->assertSame($this->customerId, $this->customer->getCustomerId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCustomerReference()
+    {
+        $this->assertSame($this->customer, $this->customer->setCustomerReference($this->customerReference));
+        $this->assertSame($this->customerReference, $this->customer->getCustomerReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->customer, $this->customer->setId($this->id));
-        $this->assertSame($this->id, $this->customer->getId());
+        $this->assertSame($this->customer, $this->customer->setId($this->customerId));
+        $this->assertSame($this->customerId, $this->customer->getId());
     }
 
     /**
      * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testReference()
     {
-        $this->assertSame($this->customer, $this->customer->setReference($this->reference));
-        $this->assertSame($this->reference, $this->customer->getReference());
+        $this->assertSame($this->customer, $this->customer->setReference($this->customerReference));
+        $this->assertSame($this->customerReference, $this->customer->getReference());
     }
 
     /**

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -15,8 +15,8 @@ class PaymentMethodTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->paymentMethod = new PaymentMethod();
-        $this->id = $this->faker->paymentMethodId();
-        $this->reference = $this->faker->paymentMethodReference();
+        $this->paymentMethodId = $this->faker->paymentMethodId();
+        $this->paymentMethodReference = $this->faker->paymentMethodReference();
     }
 
     /**
@@ -25,11 +25,11 @@ class PaymentMethodTest extends TestCase
     public function testConstructWithParams()
     {
         $paymentMethod = new PaymentMethod(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'paymentMethodId' => $this->paymentMethodId,
+            'paymentMethodReference' => $this->paymentMethodReference
         ));
-        $this->assertSame($this->id, $paymentMethod->getId());
-        $this->assertSame($this->reference, $paymentMethod->getReference());
+        $this->assertSame($this->paymentMethodId, $paymentMethod->getPaymentMethodId());
+        $this->assertSame($this->paymentMethodReference, $paymentMethod->getPaymentMethodReference());
     }
 
     /**
@@ -38,11 +38,11 @@ class PaymentMethodTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->paymentMethod, $this->paymentMethod->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'paymentMethodId' => $this->paymentMethodId,
+            'paymentMethodReference' => $this->paymentMethodReference
         )));
-        $this->assertSame($this->id, $this->paymentMethod->getId());
-        $this->assertSame($this->reference, $this->paymentMethod->getReference());
+        $this->assertSame($this->paymentMethodId, $this->paymentMethod->getPaymentMethodId());
+        $this->assertSame($this->paymentMethodReference, $this->paymentMethod->getPaymentMethodReference());
     }
 
     /**
@@ -50,26 +50,46 @@ class PaymentMethodTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->paymentMethod, $this->paymentMethod->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->paymentMethod->getParameters());
+        $this->assertSame($this->paymentMethod, $this->paymentMethod->setPaymentMethodId($this->paymentMethodId)->setPaymentMethodReference($this->paymentMethodReference));
+        $this->assertSame(array('paymentMethodId' => $this->paymentMethodId, 'paymentMethodReference' => $this->paymentMethodReference), $this->paymentMethod->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testPaymentMethodId()
+    {
+        $this->assertSame($this->paymentMethod, $this->paymentMethod->setPaymentMethodId($this->paymentMethodId));
+        $this->assertSame($this->paymentMethodId, $this->paymentMethod->getPaymentMethodId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPaymentMethodReference()
+    {
+        $this->assertSame($this->paymentMethod, $this->paymentMethod->setPaymentMethodReference($this->paymentMethodReference));
+        $this->assertSame($this->paymentMethodReference, $this->paymentMethod->getPaymentMethodReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->paymentMethod, $this->paymentMethod->setId($this->id));
-        $this->assertSame($this->id, $this->paymentMethod->getId());
+        $this->assertSame($this->paymentMethod, $this->paymentMethod->setId($this->paymentMethodId));
+        $this->assertSame($this->paymentMethodId, $this->paymentMethod->getId());
     }
 
     /**
      * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testReference()
     {
-        $this->assertSame($this->paymentMethod, $this->paymentMethod->setReference($this->reference));
-        $this->assertSame($this->reference, $this->paymentMethod->getReference());
+        $this->assertSame($this->paymentMethod, $this->paymentMethod->setReference($this->paymentMethodReference));
+        $this->assertSame($this->paymentMethodReference, $this->paymentMethod->getReference());
     }
 
     /**

--- a/tests/PlanTest.php
+++ b/tests/PlanTest.php
@@ -14,8 +14,8 @@ class PlanTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->plan = new Plan();
-        $this->id = $this->faker->planId();
-        $this->reference = $this->faker->planReference();
+        $this->planId = $this->faker->planId();
+        $this->planReference = $this->faker->planReference();
     }
 
     /**
@@ -24,11 +24,11 @@ class PlanTest extends TestCase
     public function testConstructWithParams()
     {
         $plan = new Plan(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'planId' => $this->planId,
+            'planReference' => $this->planReference
         ));
-        $this->assertSame($this->id, $plan->getId());
-        $this->assertSame($this->reference, $plan->getReference());
+        $this->assertSame($this->planId, $plan->getPlanId());
+        $this->assertSame($this->planReference, $plan->getPlanReference());
     }
 
     /**
@@ -37,11 +37,11 @@ class PlanTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->plan, $this->plan->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'planId' => $this->planId,
+            'planReference' => $this->planReference
         )));
-        $this->assertSame($this->id, $this->plan->getId());
-        $this->assertSame($this->reference, $this->plan->getReference());
+        $this->assertSame($this->planId, $this->plan->getPlanId());
+        $this->assertSame($this->planReference, $this->plan->getPlanReference());
     }
 
     /**
@@ -49,8 +49,26 @@ class PlanTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->plan, $this->plan->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->plan->getParameters());
+        $this->assertSame($this->plan, $this->plan->setPlanId($this->planId)->setPlanReference($this->planReference));
+        $this->assertSame(array('planId' => $this->planId, 'planReference' => $this->planReference), $this->plan->getParameters());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPlanId()
+    {
+        $this->assertSame($this->plan, $this->plan->setPlanId($this->planId));
+        $this->assertSame($this->planId, $this->plan->getPlanId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPlanReference()
+    {
+        $this->assertSame($this->plan, $this->plan->setPlanReference($this->planReference));
+        $this->assertSame($this->planReference, $this->plan->getPlanReference());
     }
 
     /**
@@ -58,8 +76,8 @@ class PlanTest extends TestCase
      */
     public function testId()
     {
-        $this->assertSame($this->plan, $this->plan->setId($this->id));
-        $this->assertSame($this->id, $this->plan->getId());
+        $this->assertSame($this->plan, $this->plan->setId($this->planId));
+        $this->assertSame($this->planId, $this->plan->getId());
     }
 
     /**
@@ -67,8 +85,8 @@ class PlanTest extends TestCase
      */
     public function testReference()
     {
-        $this->assertSame($this->plan, $this->plan->setReference($this->reference));
-        $this->assertSame($this->reference, $this->plan->getReference());
+        $this->assertSame($this->plan, $this->plan->setReference($this->planReference));
+        $this->assertSame($this->planReference, $this->plan->getReference());
     }
 
     /**

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -14,8 +14,8 @@ class ProductTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->product = new Product();
-        $this->id = $this->faker->productId();
-        $this->reference = $this->faker->productReference();
+        $this->productId = $this->faker->productId();
+        $this->productReference = $this->faker->productReference();
     }
 
     /**
@@ -24,11 +24,11 @@ class ProductTest extends TestCase
     public function testConstructWithParams()
     {
         $product = new Product(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'productId' => $this->productId,
+            'productReference' => $this->productReference
         ));
-        $this->assertSame($this->id, $product->getId());
-        $this->assertSame($this->reference, $product->getReference());
+        $this->assertSame($this->productId, $product->getProductId());
+        $this->assertSame($this->productReference, $product->getProductReference());
     }
 
     /**
@@ -37,11 +37,11 @@ class ProductTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->product, $this->product->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'productId' => $this->productId,
+            'productReference' => $this->productReference
         )));
-        $this->assertSame($this->id, $this->product->getId());
-        $this->assertSame($this->reference, $this->product->getReference());
+        $this->assertSame($this->productId, $this->product->getProductId());
+        $this->assertSame($this->productReference, $this->product->getProductReference());
     }
 
     /**
@@ -49,26 +49,46 @@ class ProductTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->product, $this->product->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->product->getParameters());
+        $this->assertSame($this->product, $this->product->setProductId($this->productId)->setProductReference($this->productReference));
+        $this->assertSame(array('productId' => $this->productId, 'productReference' => $this->productReference), $this->product->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testProductId()
+    {
+        $this->assertSame($this->product, $this->product->setProductId($this->productId));
+        $this->assertSame($this->productId, $this->product->getProductId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testProductReference()
+    {
+        $this->assertSame($this->product, $this->product->setProductReference($this->productReference));
+        $this->assertSame($this->productReference, $this->product->getProductReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->product, $this->product->setId($this->id));
-        $this->assertSame($this->id, $this->product->getId());
+        $this->assertSame($this->product, $this->product->setId($this->productId));
+        $this->assertSame($this->productId, $this->product->getId());
     }
 
     /**
      * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testReference()
     {
-        $this->assertSame($this->product, $this->product->setReference($this->reference));
-        $this->assertSame($this->reference, $this->product->getReference());
+        $this->assertSame($this->product, $this->product->setReference($this->productReference));
+        $this->assertSame($this->productReference, $this->product->getReference());
     }
 
     /**

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -14,8 +14,8 @@ class RefundTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->refund = new Refund();
-        $this->id = $this->faker->refundId();
-        $this->reference = $this->faker->refundReference();
+        $this->refundId = $this->faker->refundId();
+        $this->refundReference = $this->faker->refundReference();
     }
 
     /**
@@ -24,11 +24,11 @@ class RefundTest extends TestCase
     public function testConstructWithParams()
     {
         $refund = new Refund(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'refundId' => $this->refundId,
+            'refundReference' => $this->refundReference
         ));
-        $this->assertSame($this->id, $refund->getId());
-        $this->assertSame($this->reference, $refund->getReference());
+        $this->assertSame($this->refundId, $refund->getRefundId());
+        $this->assertSame($this->refundReference, $refund->getRefundReference());
     }
 
     /**
@@ -37,11 +37,11 @@ class RefundTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->refund, $this->refund->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'refundId' => $this->refundId,
+            'refundReference' => $this->refundReference
         )));
-        $this->assertSame($this->id, $this->refund->getId());
-        $this->assertSame($this->reference, $this->refund->getReference());
+        $this->assertSame($this->refundId, $this->refund->getRefundId());
+        $this->assertSame($this->refundReference, $this->refund->getRefundReference());
     }
 
     /**
@@ -49,26 +49,46 @@ class RefundTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->refund, $this->refund->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->refund->getParameters());
+        $this->assertSame($this->refund, $this->refund->setRefundId($this->refundId)->setRefundReference($this->refundReference));
+        $this->assertSame(array('refundId' => $this->refundId, 'refundReference' => $this->refundReference), $this->refund->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testRefundId()
+    {
+        $this->assertSame($this->refund, $this->refund->setRefundId($this->refundId));
+        $this->assertSame($this->refundId, $this->refund->getRefundId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRefundReference()
+    {
+        $this->assertSame($this->refund, $this->refund->setRefundReference($this->refundReference));
+        $this->assertSame($this->refundReference, $this->refund->getRefundReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->refund, $this->refund->setId($this->id));
-        $this->assertSame($this->id, $this->refund->getId());
+        $this->assertSame($this->refund, $this->refund->setId($this->refundId));
+        $this->assertSame($this->refundId, $this->refund->getId());
     }
 
     /**
      * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testReference()
     {
-        $this->assertSame($this->refund, $this->refund->setReference($this->reference));
-        $this->assertSame($this->reference, $this->refund->getReference());
+        $this->assertSame($this->refund, $this->refund->setReference($this->refundReference));
+        $this->assertSame($this->refundReference, $this->refund->getReference());
     }
 
     /**

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -7,6 +7,9 @@ use Omnipay\Tests\TestCase;
 
 class SubscriptionTest extends TestCase
 {
+    /** @var Subscription */
+    protected $subscription;
+
     /**
      * @return void
      */
@@ -14,8 +17,8 @@ class SubscriptionTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->subscription = new Subscription();
-        $this->id = $this->faker->subscriptionId();
-        $this->reference = $this->faker->subscriptionReference();
+        $this->subscriptionId = $this->faker->subscriptionId();
+        $this->subscriptionReference = $this->faker->subscriptionReference();
     }
 
     /**
@@ -24,11 +27,11 @@ class SubscriptionTest extends TestCase
     public function testConstructWithParams()
     {
         $subscription = new Subscription(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'subscriptionId' => $this->subscriptionId,
+            'subscriptionReference' => $this->subscriptionReference
         ));
-        $this->assertSame($this->id, $subscription->getId());
-        $this->assertSame($this->reference, $subscription->getReference());
+        $this->assertSame($this->subscriptionId, $subscription->getSubscriptionId());
+        $this->assertSame($this->subscriptionReference, $subscription->getSubscriptionReference());
     }
 
     /**
@@ -37,11 +40,11 @@ class SubscriptionTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->subscription, $this->subscription->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'subscriptionId' => $this->subscriptionId,
+            'subscriptionReference' => $this->subscriptionReference
         )));
-        $this->assertSame($this->id, $this->subscription->getId());
-        $this->assertSame($this->reference, $this->subscription->getReference());
+        $this->assertSame($this->subscriptionId, $this->subscription->getSubscriptionId());
+        $this->assertSame($this->subscriptionReference, $this->subscription->getSubscriptionReference());
     }
 
     /**
@@ -49,26 +52,46 @@ class SubscriptionTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->subscription, $this->subscription->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->subscription->getParameters());
+        $this->assertSame($this->subscription, $this->subscription->setSubscriptionId($this->subscriptionId)->setSubscriptionReference($this->subscriptionReference));
+        $this->assertSame(array('subscriptionId' => $this->subscriptionId, 'subscriptionReference' => $this->subscriptionReference), $this->subscription->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testSubscriptionId()
+    {
+        $this->assertSame($this->subscription, $this->subscription->setSubscriptionId($this->subscriptionId));
+        $this->assertSame($this->subscriptionId, $this->subscription->getSubscriptionId());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->subscription, $this->subscription->setId($this->id));
-        $this->assertSame($this->id, $this->subscription->getId());
+        $this->assertSame($this->subscription, $this->subscription->setId($this->subscriptionId));
+        $this->assertSame($this->subscriptionId, $this->subscription->getId());
     }
 
     /**
      * @return void
      */
+    public function testSubscriptionReference()
+    {
+        $this->assertSame($this->subscription, $this->subscription->setSubscriptionReference($this->subscriptionReference));
+        $this->assertSame($this->subscriptionReference, $this->subscription->getSubscriptionReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
+     */
     public function testReference()
     {
-        $this->assertSame($this->subscription, $this->subscription->setReference($this->reference));
-        $this->assertSame($this->reference, $this->subscription->getReference());
+        $this->assertSame($this->subscription, $this->subscription->setReference($this->subscriptionReference));
+        $this->assertSame($this->subscriptionReference, $this->subscription->getReference());
     }
 
     /**

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -7,6 +7,9 @@ use Omnipay\Tests\TestCase;
 
 class TransactionTest extends TestCase
 {
+    /** @var Transaction */
+    protected $transaction;
+
     /**
      * @return void
      */
@@ -14,8 +17,8 @@ class TransactionTest extends TestCase
     {
         $this->faker = new DataFaker();
         $this->transaction = new Transaction();
-        $this->id = $this->faker->transactionId();
-        $this->reference = $this->faker->transactionReference();
+        $this->transactionId = $this->faker->transactionId();
+        $this->transactionReference = $this->faker->transactionReference();
     }
 
     /**
@@ -24,11 +27,11 @@ class TransactionTest extends TestCase
     public function testConstructWithParams()
     {
         $transaction = new Transaction(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'transactionId' => $this->transactionId,
+            'transactionReference' => $this->transactionReference
         ));
-        $this->assertSame($this->id, $transaction->getId());
-        $this->assertSame($this->reference, $transaction->getReference());
+        $this->assertSame($this->transactionId, $transaction->getTransactionId());
+        $this->assertSame($this->transactionReference, $transaction->getTransactionReference());
     }
 
     /**
@@ -37,11 +40,11 @@ class TransactionTest extends TestCase
     public function testInitializeWithParams()
     {
         $this->assertSame($this->transaction, $this->transaction->initialize(array(
-            'id' => $this->id,
-            'reference' => $this->reference
+            'transactionId' => $this->transactionId,
+            'transactionReference' => $this->transactionReference
         )));
-        $this->assertSame($this->id, $this->transaction->getId());
-        $this->assertSame($this->reference, $this->transaction->getReference());
+        $this->assertSame($this->transactionId, $this->transaction->getTransactionId());
+        $this->assertSame($this->transactionReference, $this->transaction->getTransactionReference());
     }
 
     /**
@@ -49,26 +52,46 @@ class TransactionTest extends TestCase
      */
     public function testGetParameters()
     {
-        $this->assertSame($this->transaction, $this->transaction->setId($this->id)->setReference($this->reference));
-        $this->assertSame(array('id' => $this->id, 'reference' => $this->reference), $this->transaction->getParameters());
+        $this->assertSame($this->transaction, $this->transaction->setTransactionId($this->transactionId)->setTransactionReference($this->transactionReference));
+        $this->assertSame(array('transactionId' => $this->transactionId, 'transactionReference' => $this->transactionReference), $this->transaction->getParameters());
     }
 
     /**
      * @return void
+     */
+    public function testTransactionId()
+    {
+        $this->assertSame($this->transaction, $this->transaction->setTransactionId($this->transactionId));
+        $this->assertSame($this->transactionId, $this->transaction->getTransactionId());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
      */
     public function testId()
     {
-        $this->assertSame($this->transaction, $this->transaction->setId($this->id));
-        $this->assertSame($this->id, $this->transaction->getId());
+        $this->assertSame($this->transaction, $this->transaction->setId($this->transactionId));
+        $this->assertSame($this->transactionId, $this->transaction->getId());
     }
 
     /**
      * @return void
      */
+    public function testTransactionReference()
+    {
+        $this->assertSame($this->transaction, $this->transaction->setTransactionReference($this->transactionReference));
+        $this->assertSame($this->transactionReference, $this->transaction->getTransactionReference());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we want to make sure it still works
+     */
     public function testReference()
     {
-        $this->assertSame($this->transaction, $this->transaction->setReference($this->reference));
-        $this->assertSame($this->reference, $this->transaction->getReference());
+        $this->assertSame($this->transaction, $this->transaction->setReference($this->transactionReference));
+        $this->assertSame($this->transactionReference, $this->transaction->getReference());
     }
 
     /**


### PR DESCRIPTION
For better consistency with all other Omnipay functions.

**Changes:**
Transaction::getId -> Transaction::getTransactionId
Transaction::setId -> Transaction::setTransactionId
Transaction::getReference -> Transaction::getTransactionReference
Transaction::setReference -> Transaction::setTransactionReference
Subscription::getId -> Subscription::getSubscriptionId
Subscription::setId -> Subscription::setSubscriptionId
Subscription::getReference -> Subscription::getSubscriptionReference
Subscription::setReference -> Subscription::setSubscriptionReference

etc for all the other objects

The old way is still supported, but has been marked as deprecated