### PR TITLE
Deprecate refund 'note' in favor of 'reason'

### DIFF
--- a/src/Message/FetchRefundsRequest.php
+++ b/src/Message/FetchRefundsRequest.php
@@ -70,7 +70,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *           array('transactionItemIndexNumber' => '2', 'sku' => '2', 'amount' => '19.98')
  *       ),
  *       'amount' => '23.48', // not necessary since items are provided
- *       'note' => 'A note about the refund'
+ *       'reason' => 'The reason for the refund'
  *   ))->send();
  *
  *   if ($refundResponse->isSuccessful()) {

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -33,7 +33,7 @@ use Omnipay\Vindicia\VindiciaRefundItemBag;
  * transactionItemIndex number is the position of the item in the original transaction, indexed
  * starting at 1. A taxOnly parameter can be set to true if only the tax should be refunded.
  * Refunding by items may not work if you are using Vindicia's old tax engine.
- * - note: A note to attach to the refund. Optional.
+ * - reason: A reason to attach to the refund. Optional.
  * - attributes: Custom values you wish to have stored with the refund. They have
  * no affect on anything.
  *
@@ -87,7 +87,7 @@ use Omnipay\Vindicia\VindiciaRefundItemBag;
  *           array('transactionItemIndexNumber' => '2', 'sku' => '2', 'amount' => '19.98')
  *       ),
  *       'amount' => '23.48', // not necessary since items are provided
- *       'note' => 'A note about the refund'
+ *       'reason' => 'The reason for the refund'
  *   ))->send();
  *
  *   if ($refundResponse->isSuccessful()) {
@@ -127,24 +127,47 @@ class RefundRequest extends AbstractRequest
     }
 
     /**
-     * Get the note associated with this refund.
+     * Get the reason associated with this refund.
      *
      * @return null|string
      */
-    public function getNote()
+    public function getReason()
     {
-        return $this->getParameter('note');
+        return $this->getParameter('reason');
     }
 
     /**
-     * Set a note to be associated with this refund.
+     * Set a reason to be associated with this refund.
      *
      * @param string $value
      * @return static
      */
+    public function setReason($value)
+    {
+        return $this->setParameter('reason', $value);
+    }
+
+    /**
+     * Get the reason associated with this refund.
+     *
+     * @return null|string
+     * @deprecated in favor of getReason
+     */
+    public function getNote()
+    {
+        return $this->getReason();
+    }
+
+    /**
+     * Set a reason to be associated with this refund.
+     *
+     * @param string $value
+     * @return static
+     * @deprecated in favor of setReason
+     */
     public function setNote($value)
     {
-        return $this->setParameter('note', $value);
+        return $this->setReason($value);
     }
 
     /**
@@ -183,7 +206,7 @@ class RefundRequest extends AbstractRequest
         $refund = new stdClass();
         $refund->amount = $this->getAmount();
         $refund->currency = $this->getCurrency();
-        $refund->note = $this->getNote();
+        $refund->note = $this->getReason();
 
         $transaction = new stdClass();
         $transaction->merchantTransactionId = $transactionId;

--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -239,7 +239,7 @@ class ObjectHelper
             'refundReference' => isset($object->VID) ? $object->VID : null,
             'currency' => isset($object->currency) ? $object->currency : null,
             'amount' => isset($object->amount) ? $object->amount : null,
-            'note' => isset($object->note) ? $object->note : null,
+            'reason' => isset($object->note) ? $object->note : null,
             'time' => isset($object->timestamp) ? $object->timestamp : null,
             'transaction' => isset($transaction) ? $transaction : null,
             'transactionId' => isset($transaction) ? $transaction->getTransactionId() : null,

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -198,24 +198,47 @@ class Refund
     }
 
     /**
-     * Get the note
+     * Get the reason
      *
      * @return null|string
      */
-    public function getNote()
+    public function getReason()
     {
-        return $this->getParameter('note');
+        return $this->getParameter('reason');
     }
 
     /**
-     * Set the note
+     * Set the reason
      *
      * @param string $value
      * @return static
      */
+    public function setReason($value)
+    {
+        return $this->setParameter('reason', $value);
+    }
+
+    /**
+     * Get the reason
+     *
+     * @return null|string
+     * @deprecated in favor of getReason
+     */
+    public function getNote()
+    {
+        return $this->getReason();
+    }
+
+    /**
+     * Set the reason
+     *
+     * @param string $value
+     * @return static
+     * @deprecated in favor of setReason
+     */
     public function setNote($value)
     {
-        return $this->setParameter('note', $value);
+        return $this->setReason($value);
     }
 
     /**

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1007,6 +1007,16 @@ class DataFaker
     }
 
     /**
+     * Return a refund reason
+     *
+     * @return string
+     */
+    public function refundReason()
+    {
+        return $this->note();
+    }
+
+    /**
      * Return a note
      *
      * @return string

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -184,10 +184,7 @@ class GatewayTest extends GatewayTestCase
 
         $transactionId = $this->faker->transactionId();
         $transactionReference = $this->faker->transactionReference();
-        $note = $this->faker->randomCharacters(
-            DataFaker::ALPHABET_LOWER . DataFaker::ALPHABET_UPPER,
-            $this->faker->intBetween(10, 50)
-        );
+        $reason = $this->faker->refundReason();
 
         $request = $this->gateway->refund(
             array(
@@ -195,7 +192,7 @@ class GatewayTest extends GatewayTestCase
                 'currency' => $currency,
                 'transactionId' => $transactionId,
                 'transactionReference' => $transactionReference,
-                'note' => $note
+                'reason' => $reason
             )
         );
 
@@ -204,7 +201,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertSame($currency, $request->getCurrency());
         $this->assertSame($transactionId, $request->getTransactionId());
         $this->assertSame($transactionReference, $request->getTransactionReference());
-        $this->assertSame($note, $request->getNote());
+        $this->assertSame($reason, $request->getReason());
     }
 
     /**

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -32,7 +32,7 @@ class RefundRequestTest extends SoapTestCase
 
         $this->transactionId = $this->faker->transactionId();
         $this->transactionReference = $this->faker->transactionReference();
-        $this->note = $this->faker->note();
+        $this->reason = $this->faker->refundReason();
 
         $this->attributes = $this->faker->attributesAsArray();
 
@@ -44,7 +44,7 @@ class RefundRequestTest extends SoapTestCase
                 'currency' => $this->currency,
                 'transactionId' => $this->transactionId,
                 'transactionReference' => $this->transactionReference,
-                'note' => $this->note,
+                'reason' => $this->reason,
                 'attributes' => $this->attributes
             )
         );
@@ -70,13 +70,26 @@ class RefundRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testReason()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\RefundRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setReason($this->reason));
+        $this->assertSame($this->reason, $request->getReason());
+    }
+
+    /**
+     * @return void
+     */
     public function testNote()
     {
         $request = Mocker::mock('\Omnipay\Vindicia\Message\RefundRequest')->makePartial();
         $request->initialize();
 
-        $this->assertSame($request, $request->setNote($this->note));
-        $this->assertSame($this->note, $request->getNote());
+        $this->assertSame($request, $request->setNote($this->reason));
+        $this->assertSame($this->reason, $request->getNote());
+        $this->assertSame($this->reason, $request->getReason());
     }
 
     /**
@@ -183,7 +196,7 @@ class RefundRequestTest extends SoapTestCase
 
         $this->assertSame($this->refundAmount, $data['refunds'][0]->amount);
         $this->assertSame($this->currency, $data['refunds'][0]->currency);
-        $this->assertSame($this->note, $data['refunds'][0]->note);
+        $this->assertSame($this->reason, $data['refunds'][0]->note);
         $this->assertSame('None', $data['refunds'][0]->refundDistributionStrategy);
         $this->assertSame($this->transactionId, $data['refunds'][0]->transaction->merchantTransactionId);
         $this->assertSame($this->transactionReference, $data['refunds'][0]->transaction->VID);
@@ -206,7 +219,7 @@ class RefundRequestTest extends SoapTestCase
 
         $this->assertNull($data['refunds'][0]->amount);
         $this->assertSame($this->currency, $data['refunds'][0]->currency);
-        $this->assertSame($this->note, $data['refunds'][0]->note);
+        $this->assertSame($this->reason, $data['refunds'][0]->note);
         $this->assertSame('RemainingBalance', $data['refunds'][0]->refundDistributionStrategy);
         $this->assertSame($this->transactionId, $data['refunds'][0]->transaction->merchantTransactionId);
         $this->assertSame($this->transactionReference, $data['refunds'][0]->transaction->VID);
@@ -242,7 +255,7 @@ class RefundRequestTest extends SoapTestCase
                 $this->assertSame($refundItems[$i]['transactionItemIndexNumber'], $data['refunds'][0]->refundItems[$i]->transactionItemIndexNumber);
             }
             $this->assertSame($this->currency, $data['refunds'][0]->currency);
-            $this->assertSame($this->note, $data['refunds'][0]->note);
+            $this->assertSame($this->reason, $data['refunds'][0]->note);
             $this->assertSame('SpecifiedItems', $data['refunds'][0]->refundDistributionStrategy);
             $this->assertSame($this->transactionId, $data['refunds'][0]->transaction->merchantTransactionId);
             $this->assertSame($this->transactionReference, $data['refunds'][0]->transaction->VID);
@@ -331,7 +344,7 @@ class RefundRequestTest extends SoapTestCase
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'REFUND_ID' => $this->refundId,
             'REFUND_REFERENCE' => $this->refundReference,
-            'NOTE' => $this->note
+            'REASON' => $this->reason
         ));
 
         $response = $this->request->send();
@@ -347,7 +360,7 @@ class RefundRequestTest extends SoapTestCase
         $this->assertSame($this->refundReference, $response->getRefundReference());
         $this->assertSame($this->refundReference, $refund->getReference());
         $this->assertSame($this->refundAmount, $refund->getAmount());
-        $this->assertSame($this->note, $refund->getNote());
+        $this->assertSame($this->reason, $refund->getReason());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Refund.wsdl', $this->getLastEndpoint());
     }

--- a/tests/Mock/RefundSuccess.xml
+++ b/tests/Mock/RefundSuccess.xml
@@ -152,7 +152,7 @@
         <amountIncludesTax xmlns="" xsi:type="xsd:boolean">0</amountIncludesTax>
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <timestamp xmlns="" xsi:type="xsd:dateTime">2016-08-24T07:52:04-07:00</timestamp>
-        <note xmlns="" xsi:type="xsd:string">[NOTE]</note>
+        <note xmlns="" xsi:type="xsd:string">[REASON]</note>
         <tokenAction xmlns="" xsi:type="vin:RefundTokenAction">None</tokenAction>
         <status xmlns="" xsi:type="vin:RefundStatus">Processing</status>
       </refunds>

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -7,6 +7,9 @@ use Omnipay\Tests\TestCase;
 
 class RefundTest extends TestCase
 {
+    /** @var Refund */
+    protected $refund;
+
     /**
      * @return void
      */
@@ -114,11 +117,23 @@ class RefundTest extends TestCase
     /**
      * @return void
      */
+    public function testReason()
+    {
+        $reason = $this->faker->refundReason();
+        $this->assertSame($this->refund, $this->refund->setReason($reason));
+        $this->assertSame($reason, $this->refund->getReason());
+    }
+
+    /**
+     * @return void
+     * @psalm-suppress DeprecatedMethod because we're testing that it still works
+     */
     public function testNote()
     {
-        $note = $this->faker->note();
-        $this->assertSame($this->refund, $this->refund->setNote($note));
-        $this->assertSame($note, $this->refund->getNote());
+        $reason = $this->faker->refundReason();
+        $this->assertSame($this->refund, $this->refund->setNote($reason));
+        $this->assertSame($reason, $this->refund->getNote());
+        $this->assertSame($reason, $this->refund->getReason());
     }
 
     /**

--- a/tests/TestFramework/DataFakerTest.php
+++ b/tests/TestFramework/DataFakerTest.php
@@ -776,6 +776,16 @@ class DataFakerTest extends TestCase
     /**
      * @return void
      */
+    public function testRefundReason()
+    {
+        $refundReason = $this->faker->refundReason();
+        $this->assertTrue(is_string($refundReason));
+        $this->assertTrue(strlen($refundReason) > 0);
+    }
+
+    /**
+     * @return void
+     */
     public function testStatus()
     {
         $status = $this->faker->status();


### PR DESCRIPTION
Because 'reason' makes more sense.