### PR TITLE
Move timezone set from DataFaker to the tests

### DIFF
--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -31,7 +31,6 @@ class DataFaker
     public function __construct()
     {
         mt_srand();
-        date_default_timezone_set('Europe/London');
     }
 
     /**

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -14,6 +14,7 @@ class GatewayTest extends GatewayTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->gateway = new Gateway($this->getHttpClient(), $this->getHttpRequest());
         $this->gateway->setTestMode(true);
         $this->faker = new DataFaker();

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -18,6 +18,7 @@ class AbstractRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
         $this->request->initialize();
         $this->faker = new DataFaker();

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -17,6 +17,7 @@ class AuthorizeRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->currency = $this->faker->currency();

--- a/tests/Message/CancelSubscriptionRequestTest.php
+++ b/tests/Message/CancelSubscriptionRequestTest.php
@@ -13,6 +13,7 @@ class CancelSubscriptionRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->subscriptionId = $this->faker->subscriptionId();

--- a/tests/Message/CompleteHOARequestTest.php
+++ b/tests/Message/CompleteHOARequestTest.php
@@ -14,6 +14,7 @@ class CompleteHOARequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->webSessionReference = $this->faker->webSessionReference();

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -16,6 +16,7 @@ class CreateCustomerRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->name = $this->faker->name();

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -15,6 +15,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->subscriptionId = $this->faker->subscriptionId();

--- a/tests/Message/FetchPaymentMethodRequestTest.php
+++ b/tests/Message/FetchPaymentMethodRequestTest.php
@@ -13,6 +13,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->paymentMethodId = $this->faker->paymentMethodId();

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -17,6 +17,7 @@ class PurchaseRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->currency = $this->faker->currency();

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -16,6 +16,7 @@ class RefundRequestTest extends SoapTestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
 
         $this->refundId = $this->faker->refundId();

--- a/tests/TestFramework/DataFakerTest.php
+++ b/tests/TestFramework/DataFakerTest.php
@@ -23,6 +23,7 @@ class DataFakerTest extends TestCase
      */
     public function setUp()
     {
+        date_default_timezone_set('Europe/London');
         $this->faker = new DataFaker();
     }
 


### PR DESCRIPTION
It's not really DataFaker's responsibility. This makes it easier for people to use the DataFaker for their own testing as well.