### PR TITLE
Add support for specifying page and pageSize for fetchSubscriptions

### DIFF
--- a/src/Message/FetchSubscriptionsRequest.php
+++ b/src/Message/FetchSubscriptionsRequest.php
@@ -18,6 +18,11 @@ use stdClass;
  * - endTime: The end of the date range for which subscriptions should be fetched.
  * If fetching by date range, startTime and endTime are required and a customer cannot be
  * specified. Example: 2016-06-02T12:30:00-04:00 means June 2, 2016 @ 12:30 PM, GMT - 4 hours
+ * - pageSize: The number of results to return. Will attempt to return up to 10000 if this
+ * parameter is not specified. This request will likely time out if there are that many records
+ * to return.
+ * - page: The page number to return. Starts at 0. For example, if pageSize is 10 and page is
+ * 0, returns the first 10 results. If page is 1, returns the second 10 results. Defaults to 0.
  *
  * Example by customer:
  * <code>
@@ -66,6 +71,8 @@ use stdClass;
  */
 class FetchSubscriptionsRequest extends FetchTransactionsRequest
 {
+    const DEFAULT_PAGE_SIZE = 10000;
+
     /**
      * @return string
      */
@@ -74,12 +81,58 @@ class FetchSubscriptionsRequest extends FetchTransactionsRequest
         return self::$SUBSCRIPTION_OBJECT;
     }
 
+    /**
+     * Get the number of records to return per call
+     *
+     * @return null|int
+     */
+    public function getPageSize()
+    {
+        return $this->getParameter('pageSize');
+    }
+
+    /**
+     * Set the number of records to return per call
+     *
+     * @param int $value
+     * @return static
+     */
+    public function setPageSize($value)
+    {
+        return $this->setParameter('pageSize', $value);
+    }
+
+    /**
+     * Get the page to return. Starts at 0.
+     * For example, if pageSize is 10 and page is 0, returns the first 10
+     * results. If page is 1, returns the second 10 results.
+     *
+     * @return null|int
+     */
+    public function getPage()
+    {
+        return $this->getParameter('page');
+    }
+
+    /**
+     * Set the page to return. Starts at 0.
+     * For example, if pageSize is 10 and page is 0, returns the first 10
+     * results. If page is 1, returns the second 10 results.
+     *
+     * @param int $value
+     * @return static
+     */
+    public function setPage($value)
+    {
+        return $this->setParameter('page', $value);
+    }
+
     public function getData()
     {
         $data = parent::getData();
         // foir some reason, page and pageSize are not optional for autobills
-        $data['page'] = 0;
-        $data['pageSize'] = 10000;
+        $data['page'] = $this->getPage() ?: 0;
+        $data['pageSize'] = $this->getPageSize() ?: self::DEFAULT_PAGE_SIZE;
         return $data;
     }
 }

--- a/tests/Message/FetchSubscriptionsRequestTest.php
+++ b/tests/Message/FetchSubscriptionsRequestTest.php
@@ -19,6 +19,8 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
         $this->customerReference = $this->faker->customerReference();
         $this->startTime = $this->faker->timestamp();
         $this->endTime = $this->faker->timestamp();
+        $this->page = $this->faker->intBetween(0, 10);
+        $this->pageSize = $this->faker->intBetween(10, 10000);
         // make sure endTime is after startTime
         if ($this->endTime < $this->startTime) {
             $temp = $this->endTime;
@@ -30,7 +32,9 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
         $this->request->initialize(
             array(
                 'customerId' => $this->customerId,
-                'customerReference' => $this->customerReference
+                'customerReference' => $this->customerReference,
+                'page' => $this->page,
+                'pageSize' => $this->pageSize
             )
         );
     }
@@ -74,12 +78,54 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testPageSize()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\FetchSubscriptionsRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPageSize($this->pageSize));
+        $this->assertSame($this->pageSize, $request->getPageSize());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPage()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\FetchSubscriptionsRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPage($this->page));
+        $this->assertSame($this->page, $request->getPage());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
 
         $this->assertSame($this->customerId, $data['account']->merchantAccountId);
         $this->assertSame($this->customerReference, $data['account']->VID);
+        $this->assertSame($this->page, $data['page']);
+        $this->assertSame($this->pageSize, $data['pageSize']);
+        $this->assertSame('fetchByAccount', $data['action']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetDataDefaultPageAndSize()
+    {
+        $this->request->setPage(null);
+        $this->request->setPageSize(null);
+        $data = $this->request->getData();
+
+        $this->assertSame($this->customerId, $data['account']->merchantAccountId);
+        $this->assertSame($this->customerReference, $data['account']->VID);
+        $this->assertSame(0, $data['page']);
+        $this->assertSame(10000, $data['pageSize']);
         $this->assertSame('fetchByAccount', $data['action']);
     }
 
@@ -96,6 +142,8 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
 
         $this->assertSame($this->startTime, $data['timestamp']);
         $this->assertSame($this->endTime, $data['endTimestamp']);
+        $this->assertSame($this->page, $data['page']);
+        $this->assertSame($this->pageSize, $data['pageSize']);
         $this->assertSame('fetchDeltaSince', $data['action']);
     }
 


### PR DESCRIPTION
- pageSize: The number of results to return. Will attempt to return up to 10000 if this parameter is not specified. This request will likely time out if there are that many records to return.
- page: The page number to return. Starts at 0. For example, if pageSize is 10 and page is 0, returns the first 10 results. If page is 1, returns the second 10 results. Defaults to 0.