### PR TITLE
Allow a saved PayPal payment method to be set on a subscription

### DIFF
--- a/src/Message/CompleteCreatePayPalSubscriptionRequest.php
+++ b/src/Message/CompleteCreatePayPalSubscriptionRequest.php
@@ -19,7 +19,7 @@ namespace Omnipay\Vindicia\Message;
  * - payPalTransactionReference: When PayPal redirects to the returnUrl or cancelUrl,
  * a vindicia_vid parameter will be added to the URL. It's value must be set here.
  *
- * See CreatePayPalSubscriptioinRequest for a code example.
+ * See CreatePayPalSubscriptionRequest for a code example.
  */
 class CompleteCreatePayPalSubscriptionRequest extends AbstractRequest
 {

--- a/src/Message/CreatePayPalSubscriptionRequest.php
+++ b/src/Message/CreatePayPalSubscriptionRequest.php
@@ -21,6 +21,11 @@ namespace Omnipay\Vindicia\Message;
  * Message\CreateSubscriptionRequest for the differences between a create and update and an example.
  * Remember, you should NOT change the currency of an existing subscription.
  *
+ * If you would like to create or update a subscription to use a saved PayPal payment method without
+ * going through PayPal's site, use the Vindicia gateway instead of the Vindicia PayPal gateway. See
+ * Message\CreateSubscriptionRequest, particularly the code example about updating a subscription to
+ * use a saved payment method.
+ *
  * Example:
  * <code>
  *   // set up the gateway

--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -104,7 +104,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *   }
  *
  *   // now maybe we want to update the subscription to switch it to a different card
- *   $updateResponse = $gateway->createSubscription(array(
+ *   $updateResponse = $gateway->updateSubscription(array(
  *       'card' => array(
  *           'number' => '5555555555554444',
  *           'expiryMonth' => '01',
@@ -122,6 +122,22 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *       // These are the same as from the original $subscriptionResponse, since it's the same subscription
  *       echo "Subscription id: " . $updateResponse->getSubscriptionId() . PHP_EOL;
  *       echo "Subscription reference: " . $updateResponse->getSubscriptionReference() . PHP_EOL;
+ *   } else {
+ *       // error handling
+ *   }
+ *
+ *   // we could also update the subscription to used a saved payment method
+ *   // you should not specify a card parameter in this case
+ *   $updateResponse2 = $gateway->updateSubscription(array(
+ *       'paymentMethodId' => '1234567', // this is the ID of the saved payment method we want to use
+ *                                       // it could be a credit card or a PayPal payment method
+ *        // reference the subscription created above. you could also reference it by subscriptionReference:
+ *       'subscriptionId' => $subscriptionResponse->getSubscriptionId()
+ *       'billingDay' => 15 // Day of the month when user gets charged must be between 1-31
+ *   ))->send();
+ *
+ *   if ($updateResponse2->isSuccessful()) {
+ *       // do stuff
  *   } else {
  *       // error handling
  *   }
@@ -148,7 +164,7 @@ class CreateSubscriptionRequest extends AuthorizeRequest
         return self::$SUBSCRIPTION_OBJECT;
     }
 
-    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    public function getData($paymentMethodType = null)
     {
         $subscriptionId = $this->getSubscriptionId();
         $subscriptionReference = $this->getSubscriptionReference();

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -327,6 +327,54 @@ class CreateSubscriptionRequestTest extends SoapTestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGetDataNoCard()
+    {
+        $this->request->setCard(null);
+        $data = $this->request->getData();
+
+        $this->assertSame($this->subscriptionId, $data['autobill']->merchantAutoBillId);
+        $this->assertSame($this->planId, $data['autobill']->billingPlan->merchantBillingPlanId);
+        $this->assertSame($this->subscriptionReference, $data['autobill']->VID);
+        $this->assertSame($this->planReference, $data['autobill']->billingPlan->VID);
+        $this->assertSame(1, count($data['autobill']->items));
+        $this->assertSame($this->productId, $data['autobill']->items[0]->product->merchantProductId);
+        $this->assertSame($this->productReference, $data['autobill']->items[0]->product->VID);
+        $this->assertSame($this->customerId, $data['autobill']->account->merchantAccountId);
+        $this->assertSame($this->name, $data['autobill']->account->name);
+        $this->assertSame($this->email, $data['autobill']->account->emailAddress);
+        $this->assertSame($this->customerReference, $data['autobill']->account->VID);
+        $this->assertSame($this->currency, $data['autobill']->currency);
+        $this->assertSame($this->ip, $data['autobill']->sourceIp);
+        $this->assertSame($this->startTime, $data['autobill']->startTimestamp);
+        $this->assertSame($this->billingDay, $data['autobill']->billingDay);
+        $this->assertSame('DoNotSend', $data['autobill']->statementFormat);
+        $this->assertSame($this->statementDescriptor, $data['autobill']->billingStatementIdentifier);
+        $this->assertSame($this->paymentMethodId, $data['autobill']->paymentMethod->merchantPaymentMethodId);
+        $this->assertSame($this->paymentMethodReference, $data['autobill']->paymentMethod->VID);
+        $this->assertFalse(isset($data['autobill']->paymentMethod->creditCard));
+        $this->assertFalse(isset($data['autobill']->paymentMethod->type));
+
+        $numAttributes = count($this->attributes);
+        $this->assertSame($numAttributes, count($data['autobill']->nameValues));
+        for ($i = 0; $i < $numAttributes; $i++) {
+            $this->assertSame($this->attributes[$i]['name'], $data['autobill']->nameValues[$i]->name);
+            $this->assertSame($this->attributes[$i]['value'], $data['autobill']->nameValues[$i]->value);
+        }
+
+        $this->assertSame('update', $data['action']);
+        $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
+        $this->assertSame(true, $data['validateForFuturePayment']);
+        $this->assertSame(false, $data['ignoreAvsPolicy']);
+        $this->assertSame(false, $data['ignoreCvnPolicy']);
+        $this->assertSame(null, $data['campaignCode']);
+        $this->assertSame(false, $data['dryrun']);
+        $this->assertSame(null, $data['cancelReasonCode']);
+        $this->assertSame($this->minChargebackProbability, $data['minChargebackProbability']);
+    }
+
+    /**
      * @expectedException        \Omnipay\Common\Exception\InvalidRequestException
      * @expectedExceptionMessage Either the productId or productReference parameter is required.
      * @return                   void


### PR DESCRIPTION
Currently if you set a saved payment method ID with the CreateSubscriptionRequest, it always sets the type to credit card, so then Vindicia tries to validate the credit card and fails. Now, if you just provide a payment method ID and no other payment method details, a type won't be set so it will pass.
