### PR TITLE
Update subscription authorization behavior

### DIFF
--- a/psalm_plugins/StringChecker.php
+++ b/psalm_plugins/StringChecker.php
@@ -35,10 +35,10 @@ class StringChecker extends \Psalm\Plugin
             if (preg_match($class_or_class_method, $stmt->value)) {
                 $fq_class_name = preg_split('/[:]/', $stmt->value)[0];
 
-                $file_checker = $statements_checker->getFileChecker();
+                $project_checker = $statements_checker->getFileChecker()->project_checker;
                 if (Checker\ClassChecker::checkFullyQualifiedClassLikeName(
+                    $project_checker,
                     $fq_class_name,
-                    $file_checker,
                     $code_location,
                     $suppressed_issues
                 ) === false
@@ -48,8 +48,8 @@ class StringChecker extends \Psalm\Plugin
 
                 if ($fq_class_name !== $stmt->value) {
                     if (Checker\MethodChecker::checkMethodExists(
+                        $project_checker,
                         $stmt->value,
-                        $file_checker,
                         $code_location,
                         $suppressed_issues
                     )

--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -256,7 +256,7 @@ class CreateSubscriptionRequest extends AuthorizeRequest
         return array(
             'autobill' => $subscription,
             'action' => $this->getFunction(),
-            'immediateAuthFailurePolicy' => 'doNotSaveAutoBill',
+            'immediateAuthFailurePolicy' => 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
             'validateForFuturePayment' => $this->getShouldAuthorize() ?: false,
             'ignoreAvsPolicy' => false,
             'ignoreCvnPolicy' => false,

--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -31,7 +31,11 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * precedence over one specified on the product.
  * - startTimestamp: The time to start billing. If not specified, defaults to the current
  * time. Example: 2016-06-02T12:30:00-04:00 means June 2, 2016 @ 12:30 PM, GMT - 4 hours
- * - billingDay: the day of the month when the next charge will be issue, defaults to the day of `startTimeStamp`
+ * - billingDay: the day of the month when the next charge will be issue, defaults to the day
+ * of `startTimeStamp`
+ * - shouldAuthorize: Whether an authorization should be performed on the card before creating
+ * the subscription. If true and the authorization fails, the subscription creation will fail.
+ * Defaults to false.
  *
  * <code>
  *   // set up the gateway
@@ -147,6 +151,29 @@ use Omnipay\Common\Exception\InvalidRequestException;
 class CreateSubscriptionRequest extends AuthorizeRequest
 {
     /**
+     * Returns whether an authorization will be performed to validate the card
+     * before creating the subscription.
+     *
+     * @return null|bool
+     */
+    public function getShouldAuthorize()
+    {
+        return $this->getParameter('shouldAuthorize');
+    }
+
+    /**
+     * Sets whether an authorization will be performed to validate the card
+     * before creating the subscription.
+     *
+     * @param bool $value
+     * @return static
+     */
+    public function setShouldAuthorize($value)
+    {
+        return $this->setParameter('shouldAuthorize', $value);
+    }
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @return string
@@ -230,7 +257,7 @@ class CreateSubscriptionRequest extends AuthorizeRequest
             'autobill' => $subscription,
             'action' => $this->getFunction(),
             'immediateAuthFailurePolicy' => 'doNotSaveAutoBill',
-            'validateForFuturePayment' => true,
+            'validateForFuturePayment' => $this->getShouldAuthorize() ?: false,
             'ignoreAvsPolicy' => false,
             'ignoreCvnPolicy' => false,
             'campaignCode' => null,

--- a/tests/Message/CreatePayPalSubscriptionRequestTest.php
+++ b/tests/Message/CreatePayPalSubscriptionRequestTest.php
@@ -313,7 +313,7 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
         }
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
+        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);

--- a/tests/Message/CreatePayPalSubscriptionRequestTest.php
+++ b/tests/Message/CreatePayPalSubscriptionRequestTest.php
@@ -41,6 +41,7 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
             'country' => $this->faker->region(),
             'postcode' => $this->faker->postcode()
         );
+        $this->shouldAuthorize = $this->faker->bool();
 
         $this->request = new CreatePayPalSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
@@ -61,7 +62,8 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
                 'paymentMethodId' => $this->paymentMethodId,
                 'attributes' => $this->attributes,
                 'returnUrl' => $this->returnUrl,
-                'cancelUrl' => $this->cancelUrl
+                'cancelUrl' => $this->cancelUrl,
+                'shouldAuthorize' => $this->shouldAuthorize,
             )
         );
 
@@ -266,6 +268,18 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testShouldAuthorize()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\CreateSubscriptionRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setShouldAuthorize($this->shouldAuthorize));
+        $this->assertSame($this->shouldAuthorize, $request->getShouldAuthorize());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
@@ -300,7 +314,7 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
 
         $this->assertSame('update', $data['action']);
         $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
-        $this->assertSame(true, $data['validateForFuturePayment']);
+        $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
         $this->assertSame(null, $data['campaignCode']);

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -330,7 +330,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         }
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
+        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
@@ -378,7 +378,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         }
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
+        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -39,6 +39,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->email = $this->faker->email();
         $this->subscriptionStatus = $this->faker->subscriptionStatus();
         $this->subscriptionBillingState = $this->faker->subscriptionBillingState();
+        $this->shouldAuthorize = $this->faker->bool();
         $this->attributes = $this->faker->attributesAsArray();
 
         $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -63,6 +64,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
                 'minChargebackProbability' => $this->minChargebackProbability,
                 'name' => $this->name,
                 'email' => $this->email,
+                'shouldAuthorize' => $this->shouldAuthorize,
                 'attributes' => $this->attributes
             )
         );
@@ -277,6 +279,18 @@ class CreateSubscriptionRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testShouldAuthorize()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\CreateSubscriptionRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setShouldAuthorize($this->shouldAuthorize));
+        $this->assertSame($this->shouldAuthorize, $request->getShouldAuthorize());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
@@ -317,7 +331,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
 
         $this->assertSame('update', $data['action']);
         $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
-        $this->assertSame(true, $data['validateForFuturePayment']);
+        $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
         $this->assertSame(null, $data['campaignCode']);
@@ -365,13 +379,23 @@ class CreateSubscriptionRequestTest extends SoapTestCase
 
         $this->assertSame('update', $data['action']);
         $this->assertSame('doNotSaveAutoBill', $data['immediateAuthFailurePolicy']);
-        $this->assertSame(true, $data['validateForFuturePayment']);
+        $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
         $this->assertSame(null, $data['campaignCode']);
         $this->assertSame(false, $data['dryrun']);
         $this->assertSame(null, $data['cancelReasonCode']);
         $this->assertSame($this->minChargebackProbability, $data['minChargebackProbability']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetDataDefaultShouldAuthorize()
+    {
+        $this->request->setShouldAuthorize(null);
+        $data = $this->request->getData();
+        $this->assertFalse($data['validateForFuturePayment']);
     }
 
     /**


### PR DESCRIPTION
This PR updates the default behavior for some subscription stuff to be more reasonable.
- Don't perform authorize when creating subscriptions by default. Instead, allow it to be set by a parameter.
- If a billing is scheduled for today and auth fails, put it into the retry cycle rather than just failing to create the subscription. Retrying is Vindicia's recommended behavior.





