### PR TITLE
Don't require customer or product ids/references for subscription update

### DIFF
--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -205,13 +205,13 @@ class CreateSubscriptionRequest extends AuthorizeRequest
 
         $productId = $this->getProductId();
         $productReference = $this->getProductReference();
-        if (!$productId && !$productReference) {
+        if (!$this->isUpdate() && !$productId && !$productReference) {
             throw new InvalidRequestException('Either the productId or productReference parameter is required.');
         }
 
         $customerId = $this->getCustomerId();
         $customerReference = $this->getCustomerReference();
-        if (!$customerId && !$customerReference) {
+        if (!$this->isUpdate() && !$customerId && !$customerReference) {
             throw new InvalidRequestException('Either the customerId or customerReference parameter is required.');
         }
 

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -436,6 +436,18 @@ class CreateSubscriptionRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testProductAndCustomerIdAndReferenceOptionalForUpdates()
+    {
+        $request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest(), true);
+        $request->initialize(array(
+            'subscriptionId' => $this->subscriptionId
+        ));
+        $this->assertNotNull($request->getData());
+    }
+
+    /**
+     * @return void
+     */
     public function testSendSuccess()
     {
         $this->setMockSoapResponse('CreateSubscriptionSuccess.xml', array(


### PR DESCRIPTION
Only necessary for creating a new subscription