### PR TITLE
Don't create empty soap subobjects on CreateSubscriptionRequest

### DIFF
--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -225,33 +225,45 @@ class CreateSubscriptionRequest extends AuthorizeRequest
         $subscription->billingDay = $this->getBillingDay();
         $subscription->statementFormat = 'DoNotSend';
 
-        $account = new stdClass();
-        $account->merchantAccountId = $customerId;
-        $account->VID = $customerReference;
-        $account->name = $this->getName();
-        $account->emailAddress = $this->getEmail();
-        $subscription->account = $account;
+        $name = $this->getName();
+        $email = $this->getEmail();
+        if ($customerId !== null || $customerReference !== null || $name !== null || $email !== null) {
+            $account = new stdClass();
+            $account->merchantAccountId = $customerId;
+            $account->VID = $customerReference;
+            $account->name = $name;
+            $account->emailAddress = $email;
+            $subscription->account = $account;
+        }
 
-        $plan = new stdClass();
-        $plan->merchantBillingPlanId = $this->getPlanId();
-        $plan->VID = $this->getPlanReference();
-        $subscription->billingPlan = $plan;
+        $planId = $this->getPlanId();
+        $planReference = $this->getPlanReference();
+        if ($planId !== null || $planReference !== null) {
+            $plan = new stdClass();
+            $plan->merchantBillingPlanId = $planId;
+            $plan->VID = $planReference;
+            $subscription->billingPlan = $plan;
+        }
 
-        $product = new stdClass();
-        $product->merchantProductId = $productId;
-        $product->VID = $productReference;
+        if ($productId !== null || $productReference !== null) {
+            $product = new stdClass();
+            $product->merchantProductId = $productId;
+            $product->VID = $productReference;
 
-        $item = new stdClass();
-        $item->index = 0; //set the item index
-        $item->product = $product;
-        $subscription->items = array($item);
+            $item = new stdClass();
+            $item->index = 0; //set the item index
+            $item->product = $product;
+            $subscription->items = array($item);
+        }
 
         $attributes = $this->getAttributes();
         if ($attributes) {
             $subscription->nameValues = $this->buildNameValues($attributes);
         }
 
-        $subscription->paymentMethod = $this->buildPaymentMethod($paymentMethodType);
+        if ($this->getPaymentMethodId() !== null || $this->getPaymentMethodReference() !== null) {
+            $subscription->paymentMethod = $this->buildPaymentMethod($paymentMethodType);
+        }
 
         return array(
             'autobill' => $subscription,

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -389,6 +389,52 @@ class CreateSubscriptionRequestTest extends SoapTestCase
     }
 
     /**
+     * Make sure that empty subobjects aren't set on the autobill object
+     *
+     * @return void
+     */
+    public function testGetDataNoSubobjects()
+    {
+        $request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest(), true);
+        $request->initialize(array(
+            'subscriptionId' => $this->subscriptionId,
+            'subscriptionReference' => $this->subscriptionReference,
+            'currency' => $this->currency,
+            'statementDescriptor' => $this->statementDescriptor,
+            'ip' => $this->ip,
+            'startTime' => $this->startTime,
+            'billingDay' => $this->billingDay,
+            'minChargebackProbability' => $this->minChargebackProbability,
+            'shouldAuthorize' => $this->shouldAuthorize
+        ));
+
+        $data = $request->getData();
+
+        $this->assertSame($this->subscriptionId, $data['autobill']->merchantAutoBillId);
+        $this->assertSame($this->subscriptionReference, $data['autobill']->VID);
+        $this->assertFalse(isset($data['autobill']->billingPlan));
+        $this->assertFalse(isset($data['autobill']->items));
+        $this->assertFalse(isset($data['autobill']->account));
+        $this->assertFalse(isset($data['autobill']->paymentMethod));
+        $this->assertSame($this->currency, $data['autobill']->currency);
+        $this->assertSame($this->ip, $data['autobill']->sourceIp);
+        $this->assertSame($this->startTime, $data['autobill']->startTimestamp);
+        $this->assertSame($this->billingDay, $data['autobill']->billingDay);
+        $this->assertSame('DoNotSend', $data['autobill']->statementFormat);
+        $this->assertSame($this->statementDescriptor, $data['autobill']->billingStatementIdentifier);
+
+        $this->assertSame('update', $data['action']);
+        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
+        $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
+        $this->assertSame(false, $data['ignoreAvsPolicy']);
+        $this->assertSame(false, $data['ignoreCvnPolicy']);
+        $this->assertSame(null, $data['campaignCode']);
+        $this->assertSame(false, $data['dryrun']);
+        $this->assertSame(null, $data['cancelReasonCode']);
+        $this->assertSame($this->minChargebackProbability, $data['minChargebackProbability']);
+    }
+
+    /**
      * @return void
      */
     public function testGetDataDefaultShouldAuthorize()
@@ -431,18 +477,6 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->request->setCustomerId(null);
         $this->request->setCustomerReference(null);
         $this->request->getData();
-    }
-
-    /**
-     * @return void
-     */
-    public function testProductAndCustomerIdAndReferenceOptionalForUpdates()
-    {
-        $request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest(), true);
-        $request->initialize(array(
-            'subscriptionId' => $this->subscriptionId
-        ));
-        $this->assertNotNull($request->getData());
     }
 
     /**


### PR DESCRIPTION
If we have no data to put in a subobject, we shouldn't create a subobject at all. This may be confusing Vindicia.