### PR TITLE
Allow choice of whether to retry subscription if payment method is invalid

### DIFF
--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -36,6 +36,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * - shouldAuthorize: Whether an authorization should be performed on the card before creating
  * the subscription. If true and the authorization fails, the subscription creation will fail.
  * Defaults to false.
+ * - retryIfInvalidPaymentMethod: Should the subscription be put into the retry cycle even if
+ * Vindicia thinks that the payment method is invalid? Default false.
  *
  * <code>
  *   // set up the gateway
@@ -174,6 +176,29 @@ class CreateSubscriptionRequest extends AuthorizeRequest
     }
 
     /**
+     * Returns whether the subscription should be put into the retry cycle even
+     * if Vindicia thinks the payment method is invalid.
+     *
+     * @return null|bool
+     */
+    public function getRetryIfInvalidPaymentMethod()
+    {
+        return $this->getParameter('retryIfInvalidPaymentMethod');
+    }
+
+    /**
+     * Sets whether the subscription should be put into the retry cycle even
+     * if Vindicia thinks the payment method is invalid.
+     *
+     * @param bool $value
+     * @return static
+     */
+    public function setRetryIfInvalidPaymentMethod($value)
+    {
+        return $this->setParameter('retryIfInvalidPaymentMethod', $value);
+    }
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @return string
@@ -268,7 +293,9 @@ class CreateSubscriptionRequest extends AuthorizeRequest
         return array(
             'autobill' => $subscription,
             'action' => $this->getFunction(),
-            'immediateAuthFailurePolicy' => 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
+            'immediateAuthFailurePolicy' => $this->getRetryIfInvalidPaymentMethod()
+                                            ? 'putAutoBillInRetryCycle'
+                                            : 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
             'validateForFuturePayment' => $this->getShouldAuthorize() ?: false,
             'ignoreAvsPolicy' => false,
             'ignoreCvnPolicy' => false,

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -40,6 +40,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->subscriptionStatus = $this->faker->subscriptionStatus();
         $this->subscriptionBillingState = $this->faker->subscriptionBillingState();
         $this->shouldAuthorize = $this->faker->bool();
+        $this->retryIfInvalidPaymentMethod = $this->faker->bool();
         $this->attributes = $this->faker->attributesAsArray();
 
         $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -65,6 +66,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
                 'name' => $this->name,
                 'email' => $this->email,
                 'shouldAuthorize' => $this->shouldAuthorize,
+                'retryIfInvalidPaymentMethod' => $this->retryIfInvalidPaymentMethod,
                 'attributes' => $this->attributes
             )
         );
@@ -291,6 +293,18 @@ class CreateSubscriptionRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testRetryIfInvalidPaymentMethod()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\CreateSubscriptionRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setRetryIfInvalidPaymentMethod($this->retryIfInvalidPaymentMethod));
+        $this->assertSame($this->retryIfInvalidPaymentMethod, $request->getRetryIfInvalidPaymentMethod());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
@@ -330,7 +344,10 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         }
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
+        $this->assertSame(
+            $this->retryIfInvalidPaymentMethod ? 'putAutoBillInRetryCycle' : 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
+            $data['immediateAuthFailurePolicy']
+        );
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
@@ -378,7 +395,10 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         }
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
+        $this->assertSame(
+            $this->retryIfInvalidPaymentMethod ? 'putAutoBillInRetryCycle' : 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
+            $data['immediateAuthFailurePolicy']
+        );
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);
@@ -405,7 +425,8 @@ class CreateSubscriptionRequestTest extends SoapTestCase
             'startTime' => $this->startTime,
             'billingDay' => $this->billingDay,
             'minChargebackProbability' => $this->minChargebackProbability,
-            'shouldAuthorize' => $this->shouldAuthorize
+            'shouldAuthorize' => $this->shouldAuthorize,
+            'retryIfInvalidPaymentMethod' => $this->retryIfInvalidPaymentMethod
         ));
 
         $data = $request->getData();
@@ -424,7 +445,10 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->assertSame($this->statementDescriptor, $data['autobill']->billingStatementIdentifier);
 
         $this->assertSame('update', $data['action']);
-        $this->assertSame('putAutoBillInRetryCycleIfPaymentMethodIsValid', $data['immediateAuthFailurePolicy']);
+        $this->assertSame(
+            $this->retryIfInvalidPaymentMethod ? 'putAutoBillInRetryCycle' : 'putAutoBillInRetryCycleIfPaymentMethodIsValid',
+            $data['immediateAuthFailurePolicy']
+        );
         $this->assertSame($this->shouldAuthorize, $data['validateForFuturePayment']);
         $this->assertSame(false, $data['ignoreAvsPolicy']);
         $this->assertSame(false, $data['ignoreCvnPolicy']);


### PR DESCRIPTION
Adds retryIfInvalidPaymentMethod option which determines if the subscription be put into the retry cycle even if Vindicia thinks that the payment method is invalid. Defaults to false.