### PR TITLE
Fixed all hardcoded timestamps in mock response

### DIFF
--- a/tests/Message/FetchRefundsRequestTest.php
+++ b/tests/Message/FetchRefundsRequestTest.php
@@ -146,7 +146,7 @@ class FetchRefundsRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchRefundsSuccess.xml', [
+        $this->setMockSoapResponse('FetchRefundsSuccess.xml', array(
             'REFUND_ID' => $this->refundId,
             'REFUND_REFERENCE' => $this->refundReference,
             'TRANSACTION_ID' => $this->transactionId,
@@ -154,7 +154,7 @@ class FetchRefundsRequestTest extends SoapTestCase
             'CURRENCY' => $this->currency,
             'AMOUNT' => $this->amount,
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -191,9 +191,9 @@ class FetchRefundsRequestTest extends SoapTestCase
      */
     public function testSendByTimeSuccess()
     {
-        $this->setMockSoapResponse('FetchRefundsByTimeSuccess.xml', [
+        $this->setMockSoapResponse('FetchRefundsByTimeSuccess.xml', array(
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 

--- a/tests/Message/FetchRefundsRequestTest.php
+++ b/tests/Message/FetchRefundsRequestTest.php
@@ -38,6 +38,7 @@ class FetchRefundsRequestTest extends SoapTestCase
         $this->refundReference = $this->faker->refundReference();
         $this->currency = $this->faker->currency();
         $this->amount = $this->faker->monetaryAmount($this->currency);
+        $this->timestamp = date('Y-m-d\T12:00:00-04:00');
     }
 
     /**
@@ -145,14 +146,15 @@ class FetchRefundsRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchRefundsSuccess.xml', array(
+        $this->setMockSoapResponse('FetchRefundsSuccess.xml', [
             'REFUND_ID' => $this->refundId,
             'REFUND_REFERENCE' => $this->refundReference,
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'CURRENCY' => $this->currency,
-            'AMOUNT' => $this->amount
-        ));
+            'AMOUNT' => $this->amount,
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -189,7 +191,9 @@ class FetchRefundsRequestTest extends SoapTestCase
      */
     public function testSendByTimeSuccess()
     {
-        $this->setMockSoapResponse('FetchRefundsByTimeSuccess.xml');
+        $this->setMockSoapResponse('FetchRefundsByTimeSuccess.xml', [
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -115,7 +115,7 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionSuccess.xml', [
+        $this->setMockSoapResponse('FetchTransactionSuccess.xml', array(
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'CURRENCY' => $this->currency,
@@ -132,7 +132,7 @@ class FetchTransactionRequestTest extends SoapTestCase
             'CVV_CODE' => $this->cvvCode,
             'AVS_CODE' => $this->avsCode,
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -203,11 +203,11 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendByReferenceSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionByReferenceSuccess.xml', [
+        $this->setMockSoapResponse('FetchTransactionByReferenceSuccess.xml', array(
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -228,9 +228,9 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendFailure()
     {
-        $this->setMockSoapResponse('FetchTransactionFailure.xml', [
+        $this->setMockSoapResponse('FetchTransactionFailure.xml', array(
             'TRANSACTION_ID' => $this->transactionId,
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -248,9 +248,9 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendByReferenceFailure()
     {
-        $this->setMockSoapResponse('FetchTransactionByReferenceFailure.xml', [
+        $this->setMockSoapResponse('FetchTransactionByReferenceFailure.xml', array(
             'TRANSACTION_REFERENCE' => $this->transactionReference,
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -268,7 +268,7 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendPayPalSuccess()
     {
-        $this->setMockSoapResponse('FetchPayPalTransactionSuccess.xml', [
+        $this->setMockSoapResponse('FetchPayPalTransactionSuccess.xml', array(
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'CURRENCY' => $this->currency,
@@ -284,7 +284,7 @@ class FetchTransactionRequestTest extends SoapTestCase
             'TOKEN' => $this->token,
             'PAYPAL_EMAIL' => $this->paypalEmail,
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -45,6 +45,9 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->avsCode = $this->faker->statusCode();
         $this->token = $this->faker->payPalToken();
         $this->paypalEmail = $this->faker->email();
+
+        /* timestamp should set to current time or it will break vod test */
+        $this->timestamp = date('Y-m-d\T12:00:00-04:00');
     }
 
     /**
@@ -112,7 +115,7 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionSuccess.xml', array(
+        $this->setMockSoapResponse('FetchTransactionSuccess.xml', [
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'CURRENCY' => $this->currency,
@@ -127,8 +130,9 @@ class FetchTransactionRequestTest extends SoapTestCase
             'SKU' => $this->sku,
             'AUTHORIZATION_CODE' => $this->authorizationCode,
             'CVV_CODE' => $this->cvvCode,
-            'AVS_CODE' => $this->avsCode
-        ));
+            'AVS_CODE' => $this->avsCode,
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -189,6 +193,7 @@ class FetchTransactionRequestTest extends SoapTestCase
             $this->assertTrue(is_string($attribute->getName()));
             $this->assertTrue(is_string($attribute->getValue()));
         }
+        $this->assertEquals($this->timestamp, $transaction->getTimestamp());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
@@ -198,10 +203,11 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendByReferenceSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionByReferenceSuccess.xml', array(
+        $this->setMockSoapResponse('FetchTransactionByReferenceSuccess.xml', [
             'TRANSACTION_ID' => $this->transactionId,
-            'TRANSACTION_REFERENCE' => $this->transactionReference
-        ));
+            'TRANSACTION_REFERENCE' => $this->transactionReference,
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -212,6 +218,7 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->assertSame($this->transactionId, $response->getTransactionId());
         $this->assertSame($this->transactionReference, $response->getTransactionReference());
         $this->assertSame($this->transactionId, $response->getTransaction()->getId());
+        $this->assertEquals($this->timestamp, $response->getTransaction()->getTimestamp());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
@@ -221,9 +228,9 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendFailure()
     {
-        $this->setMockSoapResponse('FetchTransactionFailure.xml', array(
+        $this->setMockSoapResponse('FetchTransactionFailure.xml', [
             'TRANSACTION_ID' => $this->transactionId,
-        ));
+        ]);
 
         $response = $this->request->send();
 
@@ -241,9 +248,9 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendByReferenceFailure()
     {
-        $this->setMockSoapResponse('FetchTransactionByReferenceFailure.xml', array(
+        $this->setMockSoapResponse('FetchTransactionByReferenceFailure.xml', [
             'TRANSACTION_REFERENCE' => $this->transactionReference,
-        ));
+        ]);
 
         $response = $this->request->send();
 
@@ -261,7 +268,7 @@ class FetchTransactionRequestTest extends SoapTestCase
      */
     public function testSendPayPalSuccess()
     {
-        $this->setMockSoapResponse('FetchPayPalTransactionSuccess.xml', array(
+        $this->setMockSoapResponse('FetchPayPalTransactionSuccess.xml', [
             'TRANSACTION_ID' => $this->transactionId,
             'TRANSACTION_REFERENCE' => $this->transactionReference,
             'CURRENCY' => $this->currency,
@@ -275,8 +282,9 @@ class FetchTransactionRequestTest extends SoapTestCase
             'TAX_CLASSIFICATION' => $this->taxClassification,
             'SKU' => $this->sku,
             'TOKEN' => $this->token,
-            'PAYPAL_EMAIL' => $this->paypalEmail
-        ));
+            'PAYPAL_EMAIL' => $this->paypalEmail,
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -335,6 +343,7 @@ class FetchTransactionRequestTest extends SoapTestCase
             $this->assertTrue(is_string($attribute->getName()));
             $this->assertTrue(is_string($attribute->getValue()));
         }
+        $this->assertEquals($this->timestamp, $transaction->getTimestamp());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }

--- a/tests/Message/FetchTransactionsRequestTest.php
+++ b/tests/Message/FetchTransactionsRequestTest.php
@@ -35,6 +35,7 @@ class FetchTransactionsRequestTest extends SoapTestCase
                 'customerReference' => $this->customerReference
             )
         );
+        $this->timestamp = date('Y-m-d\T12:00:00-04:00', time());
     }
 
     /**
@@ -170,7 +171,9 @@ class FetchTransactionsRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionsSuccess.xml');
+        $this->setMockSoapResponse('FetchTransactionsSuccess.xml', [
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -185,6 +188,8 @@ class FetchTransactionsRequestTest extends SoapTestCase
         $this->assertInstanceOf('\Omnipay\Vindicia\Transaction', $transactions[1]);
         $this->assertNotNull($transactions[0]->getId());
         $this->assertNotNull($transactions[1]->getId());
+        $this->assertEquals($this->timestamp, $transactions[0]->getTimestamp());
+        $this->assertEquals($this->timestamp, $transactions[1]->getTimestamp());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
@@ -194,7 +199,9 @@ class FetchTransactionsRequestTest extends SoapTestCase
      */
     public function testSendByTimeSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionsByTimeSuccess.xml');
+        $this->setMockSoapResponse('FetchTransactionsByTimeSuccess.xml', [
+            'TIMESTAMP' => $this->timestamp
+        ]);
 
         $response = $this->request->send();
 
@@ -207,6 +214,8 @@ class FetchTransactionsRequestTest extends SoapTestCase
         $this->assertSame(2, count($transactions));
         $this->assertNotNull($transactions[0]->getId());
         $this->assertNotNull($transactions[1]->getId());
+        $this->assertEquals($this->timestamp, $transactions[0]->getTimestamp());
+        $this->assertEquals($this->timestamp, $transactions[1]->getTimestamp());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }

--- a/tests/Message/FetchTransactionsRequestTest.php
+++ b/tests/Message/FetchTransactionsRequestTest.php
@@ -171,9 +171,9 @@ class FetchTransactionsRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionsSuccess.xml', [
+        $this->setMockSoapResponse('FetchTransactionsSuccess.xml', array(
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 
@@ -199,9 +199,9 @@ class FetchTransactionsRequestTest extends SoapTestCase
      */
     public function testSendByTimeSuccess()
     {
-        $this->setMockSoapResponse('FetchTransactionsByTimeSuccess.xml', [
+        $this->setMockSoapResponse('FetchTransactionsByTimeSuccess.xml', array(
             'TIMESTAMP' => $this->timestamp
-        ]);
+        ));
 
         $response = $this->request->send();
 

--- a/tests/Mock/FetchPayPalTransactionSuccess.xml
+++ b/tests/Mock/FetchPayPalTransactionSuccess.xml
@@ -19,7 +19,7 @@
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">[CUSTOMER_REFERENCE]</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">[CUSTOMER_ID]</merchantAccountId>
@@ -59,7 +59,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2018-06-15T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">PayPal</paymentMethodType>
           <payPalStatus xmlns="" xsi:type="vin:TransactionStatusPayPal">
             <token xmlns="" xsi:type="xsd:string">[TOKEN]</token>

--- a/tests/Mock/FetchRefundsByTimeSuccess.xml
+++ b/tests/Mock/FetchRefundsByTimeSuccess.xml
@@ -22,7 +22,7 @@
           <currency xmlns="" xsi:type="xsd:string">USD</currency>
           <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
           <merchantTransactionId xmlns="" xsi:type="xsd:string">XYZ12345678</merchantTransactionId>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <account xmlns="" xsi:type="vin:Account">
             <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
             <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -58,7 +58,7 @@
           </sourcePaymentMethod>
           <statusLog xmlns="" xsi:type="vin:TransactionStatus">
             <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-            <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+            <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
             <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
             <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
               <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -77,7 +77,7 @@
           </statusLog>
           <statusLog xmlns="" xsi:type="vin:TransactionStatus">
             <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-            <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+            <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
             <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
             <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
               <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -125,7 +125,7 @@
         <amount xmlns="" xsi:type="xsd:decimal">140</amount>
         <amountIncludesTax xmlns="" xsi:type="xsd:boolean">0</amountIncludesTax>
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:08-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <tokenAction xmlns="" xsi:type="vin:RefundTokenAction">None</tokenAction>
         <status xmlns="" xsi:type="vin:RefundStatus">Processing</status>
       </refunds>

--- a/tests/Mock/FetchRefundsSuccess.xml
+++ b/tests/Mock/FetchRefundsSuccess.xml
@@ -22,7 +22,7 @@
           <currency xmlns="" xsi:type="xsd:string">USD</currency>
           <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
           <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <account xmlns="" xsi:type="vin:Account">
             <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
             <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -58,7 +58,7 @@
           </sourcePaymentMethod>
           <statusLog xmlns="" xsi:type="vin:TransactionStatus">
             <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-            <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+            <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
             <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
             <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
               <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -77,7 +77,7 @@
           </statusLog>
           <statusLog xmlns="" xsi:type="vin:TransactionStatus">
             <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-            <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+            <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
             <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
             <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
               <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -125,7 +125,7 @@
         <amount xmlns="" xsi:type="xsd:decimal">[AMOUNT]</amount>
         <amountIncludesTax xmlns="" xsi:type="xsd:boolean">0</amountIncludesTax>
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:08-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <tokenAction xmlns="" xsi:type="vin:RefundTokenAction">None</tokenAction>
         <status xmlns="" xsi:type="vin:RefundStatus">Processing</status>
         <nameValues xmlns="" xsi:type="vin:NameValuePair">

--- a/tests/Mock/FetchTransactionByReferenceSuccess.xml
+++ b/tests/Mock/FetchTransactionByReferenceSuccess.xml
@@ -19,7 +19,7 @@
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -55,7 +55,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -74,7 +74,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>

--- a/tests/Mock/FetchTransactionSuccess.xml
+++ b/tests/Mock/FetchTransactionSuccess.xml
@@ -19,7 +19,7 @@
         <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">[CUSTOMER_REFERENCE]</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">[CUSTOMER_ID]</merchantAccountId>
@@ -60,7 +60,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">[AUTHORIZATION_CODE]</authCode>
@@ -81,7 +81,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">[AUTHORIZATION_CODE]</authCode>

--- a/tests/Mock/FetchTransactionsByTimeSuccess.xml
+++ b/tests/Mock/FetchTransactionsByTimeSuccess.xml
@@ -19,7 +19,7 @@
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">XYZ123456</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -55,7 +55,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -74,7 +74,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -124,7 +124,7 @@
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">XYZ654321</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -160,7 +160,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -179,7 +179,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>

--- a/tests/Mock/FetchTransactionsSuccess.xml
+++ b/tests/Mock/FetchTransactionsSuccess.xml
@@ -19,7 +19,7 @@
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">XYZ123456</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -55,7 +55,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -74,7 +74,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -124,7 +124,7 @@
         <currency xmlns="" xsi:type="xsd:string">USD</currency>
         <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
         <merchantTransactionId xmlns="" xsi:type="xsd:string">XYZ654321</merchantTransactionId>
-        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
         <account xmlns="" xsi:type="vin:Account">
           <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
           <merchantAccountId xmlns="" xsi:type="xsd:string">123456789abcd</merchantAccountId>
@@ -160,7 +160,7 @@
         </sourcePaymentMethod>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">Authorized</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:05-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>
@@ -179,7 +179,7 @@
         </statusLog>
         <statusLog xmlns="" xsi:type="vin:TransactionStatus">
           <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
-          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-04T08:06:04-07:00</timestamp>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">[TIMESTAMP]</timestamp>
           <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">CreditCard</paymentMethodType>
           <creditCardStatus xmlns="" xsi:type="vin:TransactionStatusCreditCard">
             <authCode xmlns="" xsi:type="xsd:string">100</authCode>


### PR DESCRIPTION
Replace all hardcoded timestamps with the current timestamps. The hardcoded timestamp will cause the on demand tests in Vindicia response ticket to break, as transactions will be treated as already expired. Change them to be current timestamps will fix the broken unit tests in main repo.