### PR TITLE
Add sales tax address info to credit card shipping address field

### DIFF
--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -216,8 +216,6 @@ class ObjectHelper
             'paymentMethodId' => isset($object->merchantPaymentMethodId) ? $object->merchantPaymentMethodId : null,
             'paymentMethodReference' => isset($object->VID) ? $object->VID : null,
             'type' => isset($object->type) ? $object->type : null,
-            'postcode' => isset($object->billingAddress->postalCode) ? $object->billingAddress->postalCode : null,
-            'country' => isset($object->billingAddress->country) ? $object->billingAddress->country : null,
             // NonStrippingCreditCard won't remove the X's that Vindicia masks with
             'card' => new NonStrippingCreditCard($card_info),
             'attributes' => isset($nameValues) ? $this->buildAttributes($nameValues) : null

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -199,48 +199,6 @@ class PaymentMethod
     }
 
     /**
-     * Get the billing postcode.
-     *
-     * @return null|string
-     */
-    public function getPostcode()
-    {
-        return $this->getParameter('postcode');
-    }
-
-    /**
-     * Sets the billing postcode.
-     *
-     * @param string $value
-     * @return static
-     */
-    public function setPostcode($value)
-    {
-        return $this->setParameter('postcode', $value);
-    }
-
-    /**
-     * Get the billing country.
-     *
-     * @return null|string
-     */
-    public function getCountry()
-    {
-        return $this->getParameter('country');
-    }
-
-    /**
-     * Sets the billing country.
-     *
-     * @param string $value
-     * @return static
-     */
-    public function setCountry($value)
-    {
-        return $this->setParameter('country', $value);
-    }
-
-    /**
      * A list of attributes
      *
      * @return AttributeBag|null

--- a/tests/Message/FetchPaymentMethodRequestTest.php
+++ b/tests/Message/FetchPaymentMethodRequestTest.php
@@ -205,7 +205,6 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
             'PAYMENT_METHOD_REFERENCE' => $this->paymentMethodReference,
             'COUNTRY' => $this->card['country'],
             'POSTCODE' => $this->card['postcode']
-
         ));
 
         $response = $this->request->send();
@@ -222,8 +221,10 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $paymentMethod->getId());
         $this->assertSame($this->paymentMethodReference, $paymentMethod->getReference());
         $this->assertSame('PayPal', $paymentMethod->getType());
-        $this->assertSame($this->card['country'], $paymentMethod->getCountry());
-        $this->assertSame($this->card['postcode'], $paymentMethod->getPostcode());
+        $card = $paymentMethod->getCard();
+        $this->assertInstanceOf('\Omnipay\Common\CreditCard', $card);
+        $this->assertSame($this->card['country'], $card->getCountry());
+        $this->assertSame($this->card['postcode'], $card->getPostcode());
 
         $attributes = $paymentMethod->getAttributes();
         $this->assertSame(2, count($attributes));

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -53,8 +53,8 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->billingCountry = $this->faker->region();
         $this->shippingPostcode = $this->faker->postcode();
         $this->shippingCountry = $this->faker->region();
-        $this->shippingAddress1 = $this->faker->randomCharacters($this->faker::ALPHABET_UPPER, 12);
-        $this->shippingCity = $this->faker->randomCharacters($this->faker::ALPHABET_UPPER, 8);
+        $this->shippingAddress1 = $this->faker->randomCharacters(DataFaker::ALPHABET_UPPER, 12);
+        $this->shippingCity = $this->faker->randomCharacters(DataFaker::ALPHABET_UPPER, 8);
     }
 
     /**

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -141,10 +141,10 @@ class FetchTransactionRequestTest extends SoapTestCase
             'TIMESTAMP' => $this->timestamp,
             'POSTCODE' => $this->billingPostcode,
             'COUNTRY' => $this->billingCountry,
-            'SHIPPINGPOSTCODE' => $this->shippingPostcode,
-            'SHIPPINGCOUNTRY' => $this->shippingCountry,
-            'SHIPPINGADDRESS1' => $this->shippingAddress1,
-            'SHIPPINGCITY'=> $this->shippingCity
+            'SHIPPING_POSTCODE' => $this->shippingPostcode,
+            'SHIPPING_COUNTRY' => $this->shippingCountry,
+            'SHIPPING_ADDRESS_1' => $this->shippingAddress1,
+            'SHIPPING_CITY'=> $this->shippingCity
         ));
 
         $response = $this->request->send();
@@ -212,9 +212,7 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->assertEquals($this->billingPostcode, $card->getPostcode());
         $this->assertEquals($this->billingCountry, $card->getCountry());
         $this->assertEquals($this->shippingPostcode, $card->getShippingPostcode());
-        $this->assertNotEquals($this->billingPostcode, $card->getShippingPostcode());
         $this->assertEquals($this->shippingCountry, $card->getShippingCountry());
-        $this->assertNotEquals($this->billingCountry, $card->getShippingCountry());
         $this->assertEquals($this->shippingAddress1, $card->getShippingAddress1());
         $this->assertEquals($this->shippingCity, $card->getShippingCity());
 

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -48,6 +48,13 @@ class FetchTransactionRequestTest extends SoapTestCase
 
         /* timestamp should set to current time or it will break vod test */
         $this->timestamp = date('Y-m-d\T12:00:00-04:00');
+
+        $this->billingPostcode = $this->faker->postcode();
+        $this->billingCountry = $this->faker->region();
+        $this->shippingPostcode = $this->faker->postcode();
+        $this->shippingCountry = $this->faker->region();
+        $this->shippingAddress1 = $this->faker->randomCharacters($this->faker::ALPHABET_UPPER, 12);
+        $this->shippingCity = $this->faker->randomCharacters($this->faker::ALPHABET_UPPER, 8);
     }
 
     /**
@@ -131,7 +138,13 @@ class FetchTransactionRequestTest extends SoapTestCase
             'AUTHORIZATION_CODE' => $this->authorizationCode,
             'CVV_CODE' => $this->cvvCode,
             'AVS_CODE' => $this->avsCode,
-            'TIMESTAMP' => $this->timestamp
+            'TIMESTAMP' => $this->timestamp,
+            'POSTCODE' => $this->billingPostcode,
+            'COUNTRY' => $this->billingCountry,
+            'SHIPPINGPOSTCODE' => $this->shippingPostcode,
+            'SHIPPINGCOUNTRY' => $this->shippingCountry,
+            'SHIPPINGADDRESS1' => $this->shippingAddress1,
+            'SHIPPINGCITY'=> $this->shippingCity
         ));
 
         $response = $this->request->send();
@@ -194,6 +207,16 @@ class FetchTransactionRequestTest extends SoapTestCase
             $this->assertTrue(is_string($attribute->getValue()));
         }
         $this->assertEquals($this->timestamp, $transaction->getTimestamp());
+
+        $card = $paymentMethod->getCard();
+        $this->assertEquals($this->billingPostcode, $card->getPostcode());
+        $this->assertEquals($this->billingCountry, $card->getCountry());
+        $this->assertEquals($this->shippingPostcode, $card->getShippingPostcode());
+        $this->assertNotEquals($this->billingPostcode, $card->getShippingPostcode());
+        $this->assertEquals($this->shippingCountry, $card->getShippingCountry());
+        $this->assertNotEquals($this->billingCountry, $card->getShippingCountry());
+        $this->assertEquals($this->shippingAddress1, $card->getShippingAddress1());
+        $this->assertEquals($this->shippingCity, $card->getShippingCity());
 
         $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }

--- a/tests/Mock/FetchTransactionSuccess.xml
+++ b/tests/Mock/FetchTransactionSuccess.xml
@@ -134,10 +134,10 @@
         </transactionItems>
         <salesTaxAddress>
           <VID xmlns="" xsi:type="xsd:string">5b484390ebb889cd2f4fe9523c7720b8653406ed</VID>
-          <addr1 xmlns="" xsi:type="xsd:string">[SHIPPINGADDRESS1]</addr1>
-          <city xmlns="" xsi:type="xsd:string">[SHIPPINGCITY]</city>
-          <postalCode xmlns="" xsi:type="xsd:string">[SHIPPINGPOSTCODE]</postalCode>
-          <country xmlns="" xsi:type="xsd:string">[SHIPPINGCOUNTRY]</country>
+          <addr1 xmlns="" xsi:type="xsd:string">[SHIPPING_ADDRESS_1]</addr1>
+          <city xmlns="" xsi:type="xsd:string">[SHIPPING_CITY]</city>
+          <postalCode xmlns="" xsi:type="xsd:string">[SHIPPING_POSTCODE]</postalCode>
+          <country xmlns="" xsi:type="xsd:string">[SHIPPING_COUNTRY]</country>
         </salesTaxAddress>
         <sourceIp xmlns="" xsi:type="xsd:string">[IP_ADDRESS]</sourceIp>
         <nameValues xmlns="" xsi:type="vin:NameValuePair">

--- a/tests/Mock/FetchTransactionSuccess.xml
+++ b/tests/Mock/FetchTransactionSuccess.xml
@@ -132,6 +132,13 @@
           <subtotal xmlns="" xsi:type="xsd:decimal">0</subtotal>
           <total xmlns="" xsi:type="xsd:decimal">[TAX_AMOUNT]</total>
         </transactionItems>
+        <salesTaxAddress>
+          <VID xmlns="" xsi:type="xsd:string">5b484390ebb889cd2f4fe9523c7720b8653406ed</VID>
+          <addr1 xmlns="" xsi:type="xsd:string">[SHIPPINGADDRESS1]</addr1>
+          <city xmlns="" xsi:type="xsd:string">[SHIPPINGCITY]</city>
+          <postalCode xmlns="" xsi:type="xsd:string">[SHIPPINGPOSTCODE]</postalCode>
+          <country xmlns="" xsi:type="xsd:string">[SHIPPINGCOUNTRY]</country>
+        </salesTaxAddress>
         <sourceIp xmlns="" xsi:type="xsd:string">[IP_ADDRESS]</sourceIp>
         <nameValues xmlns="" xsi:type="vin:NameValuePair">
           <name xmlns="" xsi:type="xsd:string">[ATTRIBUTE_1_NAME]</name>

--- a/tests/PaymentMethodTest.php
+++ b/tests/PaymentMethodTest.php
@@ -115,26 +115,6 @@ class PaymentMethodTest extends TestCase
     /**
      * @return void
      */
-    public function testPostcode()
-    {
-        $postcode = $this->faker->postcode();
-        $this->assertSame($this->paymentMethod, $this->paymentMethod->setPostcode($postcode));
-        $this->assertSame($postcode, $this->paymentMethod->getPostcode());
-    }
-
-    /**
-     * @return void
-     */
-    public function testCountry()
-    {
-        $country = $this->faker->region();
-        $this->assertSame($this->paymentMethod, $this->paymentMethod->setCountry($country));
-        $this->assertSame($country, $this->paymentMethod->getCountry());
-    }
-
-    /**
-     * @return void
-     */
     public function testAttributes()
     {
         $attributes = array($this->faker->attribute());


### PR DESCRIPTION
Added sales tax address info to credit card shipping address field.

refactor objectHelper class to make the implementation clearer.

Remove redundant payment method getPostcode and getCountry methods