### PR TITLE
Add deactivate payment method option to create/update payment method request

### DIFF
--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -30,6 +30,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * method is validated. Default is false.
  * - skipCvvValidation: If set to true, CVV validation will not be performed when the payment
  * method is validated. Default is false.
+ * - deactivate: If set to true, the specific payment method will be deactivated on Vindicia side.
+ * Default is false.
  * - updateSubscriptions: If result is true and this request is an update to an existing payment
  * method on an account, Vindicia will update the payment method details on all subscriptions.
  * Default is true.
@@ -142,6 +144,9 @@ class CreatePaymentMethodRequest extends AbstractRequest
         }
         if (!array_key_exists('skipCvvValidation', $parameters)) {
             $parameters['skipCvvValidation'] = false;
+        }
+        if (!array_key_exists('deactivate', $parameters)) {
+            $parameters['deactivate'] = false;
         }
         if (!array_key_exists('updateSubscriptions', $parameters)) {
             $parameters['updateSubscriptions'] = true;
@@ -267,6 +272,27 @@ class CreatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
+     * If set to true we set the payment method active flag to be false
+     *
+     * @return null|bool
+     */
+    public function getDeactivatePaymentMethod()
+    {
+        return $this->getParameter('deactivate');
+    }
+
+    /**
+     * If set to true we set the payment method active flag to be false
+     *
+     * @param bool $value
+     * @return static
+     */
+    public function setDeactivatePaymentMethod($value)
+    {
+        return $this->setParameter('deactivate', $value);
+    }
+
+    /**
      * Gets whether the request is invalid if the card parameter is not set.
      *
      * @return bool
@@ -306,11 +332,16 @@ class CreatePaymentMethodRequest extends AbstractRequest
             $this->validate('card');
         }
 
+        $paymentMethod = $this->buildPaymentMethod($paymentMethodType, true);
+        if ($this->getDeactivatePaymentMethod() === true) {
+            $paymentMethod->active = false;
+        }
+
         $data = array(
             'action' => $this->getFunction(),
             'ignoreAvsPolicy' => $this->getSkipAvsValidation(),
             'ignoreCvnPolicy' => $this->getSkipCvvValidation(),
-            'paymentMethod' => $this->buildPaymentMethod($paymentMethodType, true)
+            'paymentMethod' => $paymentMethod
         );
 
         if ($this->hasCustomer()) {

--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -30,8 +30,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * method is validated. Default is false.
  * - skipCvvValidation: If set to true, CVV validation will not be performed when the payment
  * method is validated. Default is false.
- * - deactivate: If set to true, the specific payment method will be deactivated on Vindicia side.
- * Default is false.
+ * - activate: If set to false, the specific payment method will be deactivated on Vindicia side.
+ * Default is true.
  * - updateSubscriptions: If result is true and this request is an update to an existing payment
  * method on an account, Vindicia will update the payment method details on all subscriptions.
  * Default is true.
@@ -145,8 +145,8 @@ class CreatePaymentMethodRequest extends AbstractRequest
         if (!array_key_exists('skipCvvValidation', $parameters)) {
             $parameters['skipCvvValidation'] = false;
         }
-        if (!array_key_exists('deactivate', $parameters)) {
-            $parameters['deactivate'] = false;
+        if (!array_key_exists('activate', $parameters)) {
+            $parameters['activate'] = true;
         }
         if (!array_key_exists('updateSubscriptions', $parameters)) {
             $parameters['updateSubscriptions'] = true;
@@ -272,24 +272,24 @@ class CreatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
-     * If set to true we set the payment method active flag to be false
+     * If set to false we set the payment method active flag to be false
      *
      * @return null|bool
      */
-    public function getDeactivatePaymentMethod()
+    public function getActivatePaymentMethod()
     {
-        return $this->getParameter('deactivate');
+        return $this->getParameter('activate');
     }
 
     /**
-     * If set to true we set the payment method active flag to be false
+     * If set to false we set the payment method active flag to be false
      *
      * @param bool $value
      * @return static
      */
-    public function setDeactivatePaymentMethod($value)
+    public function setActivatePaymentMethod($value)
     {
-        return $this->setParameter('deactivate', $value);
+        return $this->setParameter('activate', $value);
     }
 
     /**
@@ -333,7 +333,7 @@ class CreatePaymentMethodRequest extends AbstractRequest
         }
 
         $paymentMethod = $this->buildPaymentMethod($paymentMethodType, true);
-        if ($this->getDeactivatePaymentMethod() === true) {
+        if ($this->getActivatePaymentMethod() === false) {
             $paymentMethod->active = false;
         }
 

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -95,6 +95,19 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testDeactivatePaymentMethod()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\CreatePaymentMethodRequest')->makePartial();
+        $request->initialize();
+
+        $value = $this->faker->bool();
+        $this->assertSame($request, $request->setDeactivatePaymentMethod($value));
+        $this->assertSame($value, $request->getDeactivatePaymentMethod());
+    }
+
+    /**
+     * @return void
+     */
     public function testCustomerId()
     {
         $request = Mocker::mock('\Omnipay\Vindicia\Message\CreatePaymentMethodRequest')->makePartial();
@@ -168,6 +181,7 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->card['postcode'], $data['paymentMethod']->billingAddress->postalCode);
         $this->assertSame($this->card['country'], $data['paymentMethod']->billingAddress->country);
         $this->assertSame('CreditCard', $data['paymentMethod']->type);
+        $this->assertTrue($data['paymentMethod']->active);
         $this->assertSame($this->customerId, $data['account']->merchantAccountId);
         $this->assertSame($this->customerReference, $data['account']->VID);
 
@@ -225,6 +239,22 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->customerId, $data['account']->merchantAccountId);
         $this->assertSame($this->customerReference, $data['account']->VID);
         $this->assertFalse($data['replaceOnAllAutoBills']);
+        $this->assertSame('updatePaymentMethod', $data['action']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetDataDeactivatePaymentMethod()
+    {
+        $data = $this->request->setDeactivatePaymentMethod(true)->getData();
+
+        $this->assertSame($this->paymentMethodId, $data['paymentMethod']->merchantPaymentMethodId);
+        $this->assertSame($this->paymentMethodReference, $data['paymentMethod']->VID);
+        $this->assertSame($this->card['number'], $data['paymentMethod']->creditCard->account);
+        $this->assertSame($this->card['expiryYear'], substr($data['paymentMethod']->creditCard->expirationDate, 0, 4));
+        $this->assertSame(intval($this->card['expiryMonth']), intval(substr($data['paymentMethod']->creditCard->expirationDate, 4)));
+        $this->assertFalse($data['paymentMethod']->active);
         $this->assertSame('updatePaymentMethod', $data['action']);
     }
 

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -95,14 +95,14 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
     /**
      * @return void
      */
-    public function testDeactivatePaymentMethod()
+    public function testActivatePaymentMethod()
     {
         $request = Mocker::mock('\Omnipay\Vindicia\Message\CreatePaymentMethodRequest')->makePartial();
         $request->initialize();
 
         $value = $this->faker->bool();
-        $this->assertSame($request, $request->setDeactivatePaymentMethod($value));
-        $this->assertSame($value, $request->getDeactivatePaymentMethod());
+        $this->assertSame($request, $request->setActivatePaymentMethod($value));
+        $this->assertSame($value, $request->getActivatePaymentMethod());
     }
 
     /**
@@ -247,7 +247,7 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
      */
     public function testGetDataDeactivatePaymentMethod()
     {
-        $data = $this->request->setDeactivatePaymentMethod(true)->getData();
+        $data = $this->request->setActivatePaymentMethod(false)->getData();
 
         $this->assertSame($this->paymentMethodId, $data['paymentMethod']->merchantPaymentMethodId);
         $this->assertSame($this->paymentMethodReference, $data['paymentMethod']->VID);


### PR DESCRIPTION
Add deactivate payment method option to create/update payment method request.

This is used in deactivate_payment_method script in main repo.

Since this is the only place possible to deactivate a payment method, we should enclose the changes only to this specific request.