### PR TITLE
Fix payment method active flag

### DIFF
--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -30,7 +30,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * method is validated. Default is false.
  * - skipCvvValidation: If set to true, CVV validation will not be performed when the payment
  * method is validated. Default is false.
- * - active: If set to false, Vindicia will deactivate the given payment method. Default is true.
+ * - active: If set to false, Vindicia will deactivate the given payment method.
+ * Default is true.
  * - updateSubscriptions: If result is true and this request is an update to an existing payment
  * method on an account, Vindicia will update the payment method details on all subscriptions.
  * Default is true.
@@ -271,7 +272,8 @@ class CreatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
-     * If set to false we set the payment method active flag to be false
+     * If set to false Vindicia will deactivate the given payment method.
+     * Default is true.
      *
      * @return null|bool
      */
@@ -281,7 +283,8 @@ class CreatePaymentMethodRequest extends AbstractRequest
     }
 
     /**
-     * If set to false we set the payment method active flag to be false
+     * If set to false Vindicia will deactivate the given payment method.
+     * Default is true.
      *
      * @param bool $value
      * @return static

--- a/src/Message/CreatePaymentMethodRequest.php
+++ b/src/Message/CreatePaymentMethodRequest.php
@@ -30,8 +30,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * method is validated. Default is false.
  * - skipCvvValidation: If set to true, CVV validation will not be performed when the payment
  * method is validated. Default is false.
- * - activate: If set to false, the specific payment method will be deactivated on Vindicia side.
- * Default is true.
+ * - active: If set to false, Vindicia will deactivate the given payment method. Default is true.
  * - updateSubscriptions: If result is true and this request is an update to an existing payment
  * method on an account, Vindicia will update the payment method details on all subscriptions.
  * Default is true.
@@ -145,8 +144,8 @@ class CreatePaymentMethodRequest extends AbstractRequest
         if (!array_key_exists('skipCvvValidation', $parameters)) {
             $parameters['skipCvvValidation'] = false;
         }
-        if (!array_key_exists('activate', $parameters)) {
-            $parameters['activate'] = true;
+        if (!array_key_exists('active', $parameters)) {
+            $parameters['active'] = true;
         }
         if (!array_key_exists('updateSubscriptions', $parameters)) {
             $parameters['updateSubscriptions'] = true;
@@ -276,9 +275,9 @@ class CreatePaymentMethodRequest extends AbstractRequest
      *
      * @return null|bool
      */
-    public function getActivatePaymentMethod()
+    public function getActive()
     {
-        return $this->getParameter('activate');
+        return $this->getParameter('active');
     }
 
     /**
@@ -287,9 +286,9 @@ class CreatePaymentMethodRequest extends AbstractRequest
      * @param bool $value
      * @return static
      */
-    public function setActivatePaymentMethod($value)
+    public function setActive($value)
     {
-        return $this->setParameter('activate', $value);
+        return $this->setParameter('active', $value);
     }
 
     /**
@@ -333,7 +332,7 @@ class CreatePaymentMethodRequest extends AbstractRequest
         }
 
         $paymentMethod = $this->buildPaymentMethod($paymentMethodType, true);
-        if ($this->getActivatePaymentMethod() === false) {
+        if ($this->getActive() === false) {
             $paymentMethod->active = false;
         }
 

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -95,14 +95,14 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
     /**
      * @return void
      */
-    public function testActivatePaymentMethod()
+    public function testActive()
     {
         $request = Mocker::mock('\Omnipay\Vindicia\Message\CreatePaymentMethodRequest')->makePartial();
         $request->initialize();
 
         $value = $this->faker->bool();
-        $this->assertSame($request, $request->setActivatePaymentMethod($value));
-        $this->assertSame($value, $request->getActivatePaymentMethod());
+        $this->assertSame($request, $request->setActive($value));
+        $this->assertSame($value, $request->getActive());
     }
 
     /**
@@ -245,9 +245,9 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
     /**
      * @return void
      */
-    public function testGetDataDeactivatePaymentMethod()
+    public function testGetDataPaymentMethodNotActive()
     {
-        $data = $this->request->setActivatePaymentMethod(false)->getData();
+        $data = $this->request->setActive(false)->getData();
 
         $this->assertSame($this->paymentMethodId, $data['paymentMethod']->merchantPaymentMethodId);
         $this->assertSame($this->paymentMethodReference, $data['paymentMethod']->VID);


### PR DESCRIPTION
The payment method active flag is wrongly named 'activate' previously. So this PR fixes this issue.