### PR TITLE
Make the return value of response->getInvoiceReferences consistent

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -577,7 +577,7 @@ class Response extends AbstractResponse
     public function getInvoiceReferences()
     {
         if (isset($this->data->invoicenum)) {
-            // Vindicia may mess up the field if only one invoice num is returned
+            // PHP SOAP parsing may mess up the field if only one invoice num is in the response
             // so we force it to return an array of string
             if (is_string($this->data->invoicenum)) {
                 return array($this->data->invoicenum);

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -577,6 +577,11 @@ class Response extends AbstractResponse
     public function getInvoiceReferences()
     {
         if (isset($this->data->invoicenum)) {
+            // Vindicia may mess up the field if only one invoice num is returned
+            // so we force it to return an array of string
+            if (is_string($this->data->invoicenum)) {
+                return [$this->data->invoicenum];
+            }
             return $this->data->invoicenum;
         }
         return null;

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -580,7 +580,7 @@ class Response extends AbstractResponse
             // Vindicia may mess up the field if only one invoice num is returned
             // so we force it to return an array of string
             if (is_string($this->data->invoicenum)) {
-                return [$this->data->invoicenum];
+                return array($this->data->invoicenum);
             }
             return $this->data->invoicenum;
         }


### PR DESCRIPTION
Vindicia may mess up the return field if only one invoice num is returned. So we force it to return an array of string.