### PR TITLE
Add support for Avalara tax engine

### DIFF
--- a/src/Message/CalculateSalesTaxRequest.php
+++ b/src/Message/CalculateSalesTaxRequest.php
@@ -84,6 +84,13 @@ class CalculateSalesTaxRequest extends AbstractRequest
             throw new InvalidRequestException('Either the amount or items parameter is required.');
         }
 
+        if ($this->getCustomerId() === null && $this->getCustomerReference() === null) {
+            // With the Avalara tax engine, a customer ID is required for tax to be calculated
+            // Vindicia's advice is to pass a dummy ID if you just want to calculate tax
+            // without a specific user
+            $this->setCustomerId('Dummy ID for tax calculation');
+        }
+
         // skip card validation since we only need the address info
         return array(
             'transaction' => $this->buildTransaction(),

--- a/src/Message/CalculateSalesTaxRequest.php
+++ b/src/Message/CalculateSalesTaxRequest.php
@@ -63,7 +63,7 @@ class CalculateSalesTaxRequest extends AbstractRequest
      * Vindicia's advice is to pass a dummy ID if you just want to calculate tax
      * without a specific user.
      */
-    const DUMMY_CUSTOMER_ID = 'Dummy ID for tax calculation';
+    const DUMMY_CUSTOMER_ID_FOR_TAX_CALCULATION = 'dummy_id_for_tax_calculation';
 
     /**
      * @return string
@@ -92,7 +92,7 @@ class CalculateSalesTaxRequest extends AbstractRequest
         }
 
         if ($this->getCustomerId() === null && $this->getCustomerReference() === null) {
-            $this->setCustomerId(self::DUMMY_CUSTOMER_ID);
+            $this->setCustomerId(self::DUMMY_CUSTOMER_ID_FOR_TAX_CALCULATION);
         }
 
         // skip card validation since we only need the address info

--- a/src/Message/CalculateSalesTaxRequest.php
+++ b/src/Message/CalculateSalesTaxRequest.php
@@ -59,6 +59,13 @@ use Omnipay\Common\Exception\InvalidRequestException;
 class CalculateSalesTaxRequest extends AbstractRequest
 {
     /**
+     * With the Avalara tax engine, a customer ID is required for tax to be calculated.
+     * Vindicia's advice is to pass a dummy ID if you just want to calculate tax
+     * without a specific user.
+     */
+    const DUMMY_CUSTOMER_ID = 'Dummy ID for tax calculation';
+
+    /**
      * @return string
      */
     protected function getObject()
@@ -85,10 +92,7 @@ class CalculateSalesTaxRequest extends AbstractRequest
         }
 
         if ($this->getCustomerId() === null && $this->getCustomerReference() === null) {
-            // With the Avalara tax engine, a customer ID is required for tax to be calculated
-            // Vindicia's advice is to pass a dummy ID if you just want to calculate tax
-            // without a specific user
-            $this->setCustomerId('Dummy ID for tax calculation');
+            $this->setCustomerId(self::DUMMY_CUSTOMER_ID);
         }
 
         // skip card validation since we only need the address info

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -12,7 +12,11 @@ class Response extends AbstractResponse
     /**
      * @var array<int>
      */
-    protected static $SUCCESS_CODES = array(200);
+    protected static $SUCCESS_CODES = array(
+        200,
+        202 // Authorize requests can return a 202 if the tax service goes down.
+            // Vindicia will, by default, proceed but use inclusive taxes.
+    );
 
     /**
      * @var ObjectHelper

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+use Omnipay\Vindicia\TestFramework\Mocker;
+use Omnipay\Vindicia\TestFramework\SoapTestCase;
+
+class ResponseTest extends SoapTestCase
+{
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        date_default_timezone_set('Europe/London');
+        $this->response = Mocker::mock('\Omnipay\Vindicia\Message\Response')->makePartial();
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsSuccessful()
+    {
+        $this->response->shouldReceive('getCode')->andReturn('200');
+        $this->assertTrue($this->response->isSuccessful());
+
+        // 202 on an authorize means that the tax service was unavailable,
+        // but the request still succeeded
+        $this->response = Mocker::mock('\Omnipay\Vindicia\Message\Response')->makePartial();
+        $this->response->shouldReceive('getCode')->andReturn('202');
+        $this->assertTrue($this->response->isSuccessful());
+
+        $this->response = Mocker::mock('\Omnipay\Vindicia\Message\Response')->makePartial();
+        $this->response->shouldReceive('getCode')->andReturn('400');
+        $this->assertFalse($this->response->isSuccessful());
+    }
+}


### PR DESCRIPTION
This PR makes some small changes to better support the Avalara tax engine, which is the standard tax engine that is used with CashBox.

This includes two changes:

- Counts 202 return code as successful: Vindicia will return a 202 if the tax service goes down, but the transaction will still go through, so this should be counted as successful.
- If calculateSalesTax is called without customer, set a dummy value: The Avalara tax engine requires a customer to be set. Vindicia's advice if you don't want to do that is just to set a dummy value.