### PR TITLE
Updated ApplePayAuthorizeRequest's getData

### DIFF
--- a/src/Message/ApplePayAuthorizeRequest.php
+++ b/src/Message/ApplePayAuthorizeRequest.php
@@ -324,8 +324,9 @@ class ApplePayAuthorizeRequest extends \Omnipay\Common\Message\AbstractRequest
         $data = array();
 
         // Required request parameters for Apple Session object.
-        $data['merchantIdentifier'] = $this->getMerchantIdentifier();
+        $data['validationUrl'] = $this->getValidationUrl();
         $data['displayName'] = $this->getDisplayName();
+        $data['merchantIdentifier'] = $this->getMerchantIdentifier();
         // Default parameter for Apple Pay on the Web.
         $data['initiative'] = 'web';
         $data['initiativeContext'] = $this->getApplicationUrl();


### PR DESCRIPTION
Added `getValidationUrl()` in Apple Pay Request file so that we're getting all data needed to make an Apple Pay authorize call.