### PR TITLE
Add support for paging to fetchChargebacks request

### DIFF
--- a/src/Message/AbstractPageableRequest.php
+++ b/src/Message/AbstractPageableRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+/**
+ * Abstract request for requests that are pageable. These requests have a page (number) and
+ * pageSize parameter.
+ *
+ * - pageSize: The number of results to return.
+ * - page: The page number to return. Starts at 0. For example, if pageSize is 10 and page is
+ * 0, returns the first 10 results. If page is 1, returns the second 10 results.
+ */
+abstract class AbstractPageableRequest extends AbstractRequest
+{
+    const DEFAULT_PAGE_SIZE = 10000;
+
+    /**
+     * Get the number of records to return per call
+     *
+     * @return null|int
+     */
+    public function getPageSize()
+    {
+        return $this->getParameter('pageSize');
+    }
+
+    /**
+     * Set the number of records to return per call
+     *
+     * @param int $value
+     * @return static
+     */
+    public function setPageSize($value)
+    {
+        return $this->setParameter('pageSize', $value);
+    }
+
+    /**
+     * Get the page to return. Starts at 0.
+     * For example, if pageSize is 10 and page is 0, returns the first 10
+     * results. If page is 1, returns the second 10 results.
+     *
+     * @return null|int
+     */
+    public function getPage()
+    {
+        return $this->getParameter('page');
+    }
+
+    /**
+     * Set the page to return. Starts at 0.
+     * For example, if pageSize is 10 and page is 0, returns the first 10
+     * results. If page is 1, returns the second 10 results.
+     *
+     * @param int $value
+     * @return static
+     */
+    public function setPage($value)
+    {
+        return $this->setParameter('page', $value);
+    }
+}

--- a/src/Message/FetchChargebacksRequest.php
+++ b/src/Message/FetchChargebacksRequest.php
@@ -19,6 +19,14 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * - endTime: The end of the date range for which chargebacks should be fetched.
  * If fetching by date range, startTime and endTime are required and a transaction cannot be
  * specified. Example: 2016-06-02T12:30:00-04:00 means June 2, 2016 @ 12:30 PM, GMT - 4 hours
+ * - pageSize: The number of results to return. Will attempt to return up to 10000 if this
+ * parameter is not specified. This request will likely time out if there are that many records
+ * to return. Note: This only applies if fetching by time range. If fetching by transaction,
+ * all chargebacks will be returned.
+ * - page: The page number to return. Starts at 0. For example, if pageSize is 10 and page is
+ * 0, returns the first 10 results. If page is 1, returns the second 10 results. Defaults to 0.
+ * Note: This only applies if fetching by time range. If fetching by transaction, all
+ * chargebacks will be returned.
  *
  * Example:
  * <code>
@@ -74,7 +82,9 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *   // Alternatively, we could fetch the chargebacks by date range
  *   $fetchResponse = $gateway->fetchChargebacks(array(
  *       'startTime' => '2016-06-01T12:30:00-04:00',
- *       'endTime' => '2016-07-01T12:30:00-04:00'
+ *       'endTime' => '2016-07-01T12:30:00-04:00',
+ *       'page' => 0,
+ *       'pageSize' => 100
  *   ))->send();
  *
  *   if ($fetchResponse->isSuccessful()) {
@@ -82,7 +92,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *   }
  * </code>
  */
-class FetchChargebacksRequest extends AbstractRequest
+class FetchChargebacksRequest extends AbstractPageableRequest
 {
     /**
      * The name of the function to be called in Vindicia's API
@@ -135,6 +145,8 @@ class FetchChargebacksRequest extends AbstractRequest
         } else {
             $data['timestamp'] = $startTime;
             $data['endTimestamp'] = $endTime;
+            $data['page'] = $this->getPage() ?: 0;
+            $data['pageSize'] = $this->getPageSize() ?: self::DEFAULT_PAGE_SIZE;
         }
 
         return $data;

--- a/src/Message/FetchSubscriptionsRequest.php
+++ b/src/Message/FetchSubscriptionsRequest.php
@@ -71,8 +71,6 @@ use stdClass;
  */
 class FetchSubscriptionsRequest extends FetchTransactionsRequest
 {
-    const DEFAULT_PAGE_SIZE = 10000;
-
     /**
      * @return string
      */
@@ -81,56 +79,10 @@ class FetchSubscriptionsRequest extends FetchTransactionsRequest
         return self::$SUBSCRIPTION_OBJECT;
     }
 
-    /**
-     * Get the number of records to return per call
-     *
-     * @return null|int
-     */
-    public function getPageSize()
-    {
-        return $this->getParameter('pageSize');
-    }
-
-    /**
-     * Set the number of records to return per call
-     *
-     * @param int $value
-     * @return static
-     */
-    public function setPageSize($value)
-    {
-        return $this->setParameter('pageSize', $value);
-    }
-
-    /**
-     * Get the page to return. Starts at 0.
-     * For example, if pageSize is 10 and page is 0, returns the first 10
-     * results. If page is 1, returns the second 10 results.
-     *
-     * @return null|int
-     */
-    public function getPage()
-    {
-        return $this->getParameter('page');
-    }
-
-    /**
-     * Set the page to return. Starts at 0.
-     * For example, if pageSize is 10 and page is 0, returns the first 10
-     * results. If page is 1, returns the second 10 results.
-     *
-     * @param int $value
-     * @return static
-     */
-    public function setPage($value)
-    {
-        return $this->setParameter('page', $value);
-    }
-
     public function getData()
     {
         $data = parent::getData();
-        // foir some reason, page and pageSize are not optional for autobills
+        // for some reason, page and pageSize are not optional for autobills
         $data['page'] = $this->getPage() ?: 0;
         $data['pageSize'] = $this->getPageSize() ?: self::DEFAULT_PAGE_SIZE;
         return $data;

--- a/src/Message/FetchTransactionsRequest.php
+++ b/src/Message/FetchTransactionsRequest.php
@@ -72,10 +72,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *
  * </code>
  */
-class FetchTransactionsRequest extends AbstractRequest
+class FetchTransactionsRequest extends AbstractPageableRequest
 {
-    const DEFAULT_PAGE_SIZE = 1000;
-
     /**
      * The name of the function to be called in Vindicia's API
      *
@@ -92,52 +90,6 @@ class FetchTransactionsRequest extends AbstractRequest
     protected function getObject()
     {
         return self::$TRANSACTION_OBJECT;
-    }
-
-    /**
-     * Get the number of records to return per call
-     *
-     * @return null|int
-     */
-    public function getPageSize()
-    {
-        return $this->getParameter('pageSize');
-    }
-
-    /**
-     * Set the number of records to return per call
-     *
-     * @param int $value
-     * @return static
-     */
-    public function setPageSize($value)
-    {
-        return $this->setParameter('pageSize', $value);
-    }
-
-    /**
-     * Get the page to return. Starts at 0.
-     * For example, if pageSize is 10 and page is 0, returns the first 10
-     * results. If page is 1, returns the second 10 results.
-     *
-     * @return null|int
-     */
-    public function getPage()
-    {
-        return $this->getParameter('page');
-    }
-
-    /**
-     * Set the page to return. Starts at 0.
-     * For example, if pageSize is 10 and page is 0, returns the first 10
-     * results. If page is 1, returns the second 10 results.
-     *
-     * @param int $value
-     * @return static
-     */
-    public function setPage($value)
-    {
-        return $this->setParameter('page', $value);
     }
 
     public function getData()

--- a/tests/Message/FetchChargebacksRequestTest.php
+++ b/tests/Message/FetchChargebacksRequestTest.php
@@ -19,6 +19,8 @@ class FetchChargebacksRequestTest extends SoapTestCase
         $this->transactionReference = $this->faker->transactionReference();
         $this->startTime = $this->faker->timestamp();
         $this->endTime = $this->faker->timestamp();
+        $this->page = $this->faker->intBetween(0, 10);
+        $this->pageSize = $this->faker->intBetween(10, 10000);
         // make sure endTime is after startTime
         if ($this->endTime < $this->startTime) {
             $temp = $this->endTime;
@@ -94,6 +96,30 @@ class FetchChargebacksRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testPageSize()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\FetchChargebacksRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPageSize($this->pageSize));
+        $this->assertSame($this->pageSize, $request->getPageSize());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPage()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\FetchChargebacksRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPage($this->page));
+        $this->assertSame($this->page, $request->getPage());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
@@ -123,10 +149,14 @@ class FetchChargebacksRequestTest extends SoapTestCase
         $this->request->setStartTime($this->startTime);
         $this->request->setEndTime($this->endTime);
         $this->request->setTransactionId(null);
+        $this->request->setPage($this->page);
+        $this->request->setPageSize($this->pageSize);
         $data = $this->request->getData();
 
         $this->assertSame($this->startTime, $data['timestamp']);
         $this->assertSame($this->endTime, $data['endTimestamp']);
+        $this->assertSame($this->page, $data['page']);
+        $this->assertSame($this->pageSize, $data['pageSize']);
         $this->assertSame('fetchDeltaSince', $data['action']);
     }
 


### PR DESCRIPTION
When fetching chargebacks in a date range, you can now specify a page size and page number to fetch, instead of fetching all at once.

I created an AbstractPageableRequest to contain paging logic since there are several requests that support paging. I would have done a trait, but Omnipay 2 supports versions of PHP that don't support traits.