### PR TITLE
Update ErrorEvent instantiation to include request object

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -951,7 +951,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         } catch (SoapFault $exception) {
             if ($this->eventDispatcher) {
                 // Log any errors.
-                $this->eventDispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR, new ErrorEvent($exception));
+                $this->eventDispatcher->dispatch(
+                    Constants::OMNIPAY_REQUEST_ERROR,
+                    new ErrorEvent($exception, $this)
+                );
             }
 
             throw $exception;

--- a/src/Message/ApplePayAuthorizeRequest.php
+++ b/src/Message/ApplePayAuthorizeRequest.php
@@ -425,7 +425,10 @@ class ApplePayAuthorizeRequest extends \Omnipay\Common\Message\AbstractRequest
         } catch (Exception $exception) {
             if ($eventDispatcher) {
                 // Log any errors with the request.
-                $eventDispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR, new ErrorEvent($exception));
+                $eventDispatcher->dispatch(
+                    Constants::OMNIPAY_REQUEST_ERROR,
+                    new ErrorEvent($exception, $this)
+                );
             }
 
             throw $exception;


### PR DESCRIPTION
* Quick fix to update the `ErrorEvent` constructor to take in the new required request object param.