### PR TITLE
Add support for completeAuthorize and capture for Apple Pay.

### DIFF
--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -232,6 +232,7 @@ class ApplePayGateway extends AbstractVindiciaGateway
 
     /**
      * Capture an Apple Pay purchase.
+     * See CaptureRequest for parameter examples.
      *
      * @param array $parameters
      * @return \Omnipay\Vindicia\Message\CaptureRequest

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -7,9 +7,6 @@ namespace Omnipay\Vindicia;
  * This Apple Pay Gateway provides the functionality to authorize, complete authorize and capture
  * Apple Pay payments for Apple Pay on the web.
  * 
- * // TODO: Add documentation about functionality for capture and completeAuthorize methods to capture
- * // and authorize payments.
- * 
  * Apple Pay is available on all iOS devices with a Secure Element —– an industry-standard, certified
  * chip designed to store payment information safely. On macOS, users must have anApple Pay-capable
  * iPhone or Apple Watch to authorize the payment, or a MacBook Pro with Touch ID.
@@ -35,9 +32,9 @@ namespace Omnipay\Vindicia;
  * (via the response object) you can pass it to the front end to fully load the payment sheet and accept user payment.
  *
  * After the payment sheet is fully loaded, the user can authorize a payment using either Touch or Face ID.
- * The Apple Pay gateway can then use ApplePayCompleteAuthorize to authorize a payment –– no money will be
- * transferred during this step. If the response is successful, the gateway then makes a capture call to 
- * capture a payment and money will be received.
+ * The Apple Pay gateway can then use ApplePayCompleteAuthorize to authorize a payment using the ApplePayPaymentToken
+ * –– no money will be transferred during this step. If the response is successful, the gateway then makes
+ * a capture call to capture a payment and money will be received.
  *
  * <code>
  *    // Setup the gateway with your username and password for Vindicia.

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -31,11 +31,11 @@ namespace Omnipay\Vindicia;
  * object to retrieve an Apple Pay payment session from Apple's servers. Once the session is retrieved
  * (via the response object) you can pass it to the front end to fully load the payment sheet and accept user payment.
  *
- * After the Apple Pay payment sheet is fully loaded on the frontend. The user can authorize a payment using
+ * After the Apple Pay payment sheet is fully loaded on the frontend, the user can authorize a payment using
  * Touch or Face ID –– this will grant access to the ApplePayPaymentToken. The Apple Pay gateway can authorize 
- * a payment using the ApplePayCompleteAuthorizeRequest with the ApplePayPaymentToken passed in –– no money will 
- * be transferred during this step. If the response is successful, the gateway then makes a capture call using 
- * CaptureRequest to capture a payment and money will be received.
+ * a payment using the ApplePayCompleteAuthorizeRequest with the ApplePayPaymentToken and AuthorizeRequest parameters 
+ * passed in –– no money will be transferred during this step. If the response is successful, the gateway then 
+ * makes a capture call using CaptureRequest to capture a payment and money will be received.
  *
  * <code>
  *    // Setup the gateway with your username and password for Vindicia.
@@ -91,8 +91,8 @@ namespace Omnipay\Vindicia;
  *    // Pass the extracted 'token' to the 'applePayToken' parameter of the ApplePayCompleteAuthorizeRequest class.
  *    // You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
  *    $completeAuthorizeResponse = $gateway->completeAuthorize(array(
- *        'applePayToken' => $apple_pay_payment_session_object['token'];
- *        // Params needed to authorize a payment can go here as well.
+ *        'applePayToken' => $apple_pay_token;
+ *        // For a successful transaction, parameters for an AuthorizeRequest are needed as well.
  *        'items' => array(
  *           array('name' => 'Item 1', 'sku' => '1', 'price' => '3.50', 'quantity' => 1),
  *           array('name' => 'Item 2', 'sku' => '2', 'price' => '9.99', 'quantity' => 2)

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -87,8 +87,9 @@ namespace Omnipay\Vindicia;
  *     // payment option and shipping methods (if needed) and submit their payment.
  *
  *    // After the user authorizes an Apple Pay payment on the payment sheet using Touch or Face ID on the front end, 
- *    // parse the ApplePayPayment object to retrieve the token. Pass the extracted 'token' to the 'applePayToken' 
- *    // parameter of this class. You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
+ *    // parse the ApplePayPayment object to retrieve the token.
+ *    // Pass the extracted 'token' to the 'applePayToken' parameter of the ApplePayCompleteAuthorizeRequest class.
+ *    // You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
  *    $completeAuthorizeResponse = $gateway->completeAuthorize(array(
  *        'applePayToken' => $apple_pay_payment_session_object['token'];
  *        // Params needed to authorize a payment can go here as well.

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -102,11 +102,11 @@ namespace Omnipay\Vindicia;
  *       'customerId' => '123456', // will be created if it doesn't already exist
  *       'card' => array(
  *          'address1'   => $data->getAddress1(),
-            'address2'   => $data->getAddress2(),
-            'city'       => $data->getCity(),
-            'state'      => $data->getState(),
-            'postcode'   => $data->getPostalCode(),
-            'country'    => $data->getCountry()
+ *          'address2'   => $data->getAddress2(),
+ *          'city'       => $data->getCity(),
+ *          'state'      => $data->getState(),
+ *          'postcode'   => $data->getPostalCode(),
+ *          'country'    => $data->getCountry()
  *       ),
  *       'paymentMethodId' => 'cc-123456', // this ID will be assigned to the card, which will
  *                                         // be attached to the customer's account

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -35,9 +35,9 @@ namespace Omnipay\Vindicia;
  * (via the response object) you can pass it to the front end to fully load the payment sheet and accept user payment.
  *
  * After the payment sheet is fully loaded, the user can authorize a payment using either Touch or Face ID.
- * The Apple Pay gateway can then use ApplePayCompleteAuthorize to authorize a payment –– no money will be transferred 
- * during this step. If the response is successful, the gateway then makes a capture call to capture a payment and money
- * will be received.
+ * The Apple Pay gateway can then use ApplePayCompleteAuthorize to authorize a payment –– no money will be
+ * transferred during this step. If the response is successful, the gateway then makes a capture call to 
+ * capture a payment and money will be received.
  *
  * <code>
  *    // Setup the gateway with your username and password for Vindicia.

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -31,10 +31,11 @@ namespace Omnipay\Vindicia;
  * object to retrieve an Apple Pay payment session from Apple's servers. Once the session is retrieved
  * (via the response object) you can pass it to the front end to fully load the payment sheet and accept user payment.
  *
- * After the payment sheet is fully loaded, the user can authorize a payment using either Touch or Face ID.
- * The Apple Pay gateway can then use ApplePayCompleteAuthorize to authorize a payment using the ApplePayPaymentToken
- * –– no money will be transferred during this step. If the response is successful, the gateway then makes
- * a capture call to capture a payment and money will be received.
+ * After the Apple Pay payment sheet is fully loaded on the frontend. The user can authorize a payment using
+ * Touch or Face ID –– this will grant access to the ApplePayPaymentToken. The Apple Pay gateway can authorize 
+ * a payment using the ApplePayCompleteAuthorizeRequest with the ApplePayPaymentToken passed in –– no money will 
+ * be transferred during this step. If the response is successful, the gateway then makes a capture call using 
+ * CaptureRequest to capture a payment and money will be received.
  *
  * <code>
  *    // Setup the gateway with your username and password for Vindicia.

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -78,20 +78,40 @@ namespace Omnipay\Vindicia;
  *        echo 'Status Message: ' . $authorizeResponse->getMessage() . PHP_EOL;
  *    }
  *
- *    //Pass authorizeResponse back to the client to validate your merchant and continue with an Apple Pay payment.
- *    //If successful, the payment sheet should be fully loaded.
+ *    // Pass authorizeResponse back to the client to validate your merchant and continue with an Apple Pay payment.
+ *    // If successful, the payment sheet should be fully loaded.
  *    $apple_pay_session = $authorizeResponse->getPaymentSessionObject();
  *
  *     // An opaque Apple Pay Session is returned as a response (expires after 5 mins) and it can be sent to
  *     // the front end to fully load the payment sheet. This allows the user to optionally configure their
  *     // payment option and shipping methods (if needed) and submit their payment.
  *
- *    //After the user authorizes an Apple Pay payment on the payment sheet using Touch or Face ID, parse the 
- *    //ApplePayPayment object to retrieve the token. Pass the token to completeAuthorize to authorize a transaction.
- *    //You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
+ *    // After the user authorizes an Apple Pay payment on the payment sheet using Touch or Face ID on the front end, 
+ *    // parse the ApplePayPayment object to retrieve the token. Pass the extracted 'token' to the 'applePayToken' 
+ *    // parameter of this class. You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
  *    $completeAuthorizeResponse = $gateway->completeAuthorize(array(
- *        //Other params needed to authorize a payment can go here as well.
  *        'applePayToken' => $apple_pay_payment_session_object['token'];
+ *        // Params needed to authorize a payment can go here as well.
+ *        'items' => array(
+ *           array('name' => 'Item 1', 'sku' => '1', 'price' => '3.50', 'quantity' => 1),
+ *           array('name' => 'Item 2', 'sku' => '2', 'price' => '9.99', 'quantity' => 2)
+ *       ),
+ *       'amount' => '23.48', // not necessary since items are provided
+ *       'currency' => 'USD',
+ *       'customerId' => '123456', // will be created if it doesn't already exist
+ *       'card' => array(
+ *          'address1'   => $data->getAddress1(),
+            'address2'   => $data->getAddress2(),
+            'city'       => $data->getCity(),
+            'state'      => $data->getState(),
+            'postcode'   => $data->getPostalCode(),
+            'country'    => $data->getCountry()
+ *       ),
+ *       'paymentMethodId' => 'cc-123456', // this ID will be assigned to the card, which will
+ *                                         // be attached to the customer's account
+ *       'attributes' => array(
+ *           'location' => 'FL'
+ *       )
  *    ))->send();
  *
  *    if ($completeAuthorizeResponse->isSuccessful()) {

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -217,16 +217,17 @@ class ApplePayGateway extends AbstractVindiciaGateway
 
     /**
      * Authorize an Apple Pay purchase.
+     * See ApplePayCompleteAuthorizeRequest for parameter examples.
      *
      * @param array $parameters
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return \Omnipay\Vindicia\Message\ApplePayCompleteAuthorizeRequest
      */
     public function completeAuthorize(array $parameters = array())
     {
         /**
-         * @var  \Omnipay\Vindicia\Message\AuthorizeRequest
+         * @var  \Omnipay\Vindicia\Message\ApplePayCompleteAuthorizeRequest
          */
-        return $this->createRequest('\Omnipay\Vindicia\Message\AuthorizeRequest', $parameters);
+        return $this->createRequest('\Omnipay\Vindicia\Message\ApplePayCompleteAuthorizeRequest', $parameters);
     }
 
     /**
@@ -257,6 +258,24 @@ class ApplePayGateway extends AbstractVindiciaGateway
          * @var \Omnipay\Vindicia\Message\CreatePaymentMethodRequest
          */
         return $this->createRequest('\Omnipay\Vindicia\Message\CreatePaymentMethodRequest', $parameters, true);
+    }
+
+    /**
+     * Voids, or cancels, a previously authorized transaction. Will not work if the transaction
+     * has already been captured, either by the capture function or purchase function. This is
+     * identical to a regular void request.
+     *
+     * See Message\VoidRequest for more details.
+     *
+     * @param array $parameters
+     * @return \Omnipay\Vindicia\Message\VoidRequest
+     */
+    public function void(array $parameters = array())
+    {
+        /**
+         * @var \Omnipay\Vindicia\Message\VoidRequest
+         */
+        return $this->createRequest('\Omnipay\Vindicia\Message\VoidRequest', $parameters);
     }
 
     // see AbstractVindiciaGateway for more functions and documentation

--- a/src/ApplePayGateway.php
+++ b/src/ApplePayGateway.php
@@ -91,7 +91,7 @@ namespace Omnipay\Vindicia;
  *    //You may use other fields in the ApplePayPayment object to fill out billing or shipping info.
  *    $completeAuthorizeResponse = $gateway->completeAuthorize(array(
  *        //Other params needed to authorize a payment can go here as well.
- *        'token' => $apple_pay_payment_session_object['token'];
+ *        'applePayToken' => $apple_pay_payment_session_object['token'];
  *    ))->send();
  *
  *    if ($completeAuthorizeResponse->isSuccessful()) {

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1145,8 +1145,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             $token = $this->getToken();
             $applePay->paymentInstrumentName = $token['paymentMethod']['displayName'];
             $applePay->paymentNetwork = $token['paymentMethod']['network'];
-            $applePay->paymentData = $token['paymentData'];
             $applePay->transactionIdentifier = $token['transactionIdentifier'];
+            $applePay->paymentData = $token['paymentData'];
 
             $paymentMethod->applePay = $applePay;
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1151,7 +1151,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             if (!$this->isUpdate()) {
                 $paymentMethod->type = self::PAYMENT_METHOD_PAYPAL;
             }
-        } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY) {
+        } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY && $card) {
+            // $card parameter is needed for successful authorization.
             $applePay = new stdClass();
 
             // 'applePayToken' is validated to ensure it's set before reaching here.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1154,6 +1154,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY) {
             $applePay = new stdClass();
 
+            // 'applePayToken' is validated to ensure it's set before reaching here.
             $token = $this->getApplePayToken();
             $applePay->paymentInstrumentName = $token['paymentMethod']['displayName'];
             $applePay->paymentNetwork = $token['paymentMethod']['network'];

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1158,7 +1158,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             $applePay->paymentInstrumentName = $token['paymentMethod']['displayName'];
             $applePay->paymentNetwork = $token['paymentMethod']['network'];
             $applePay->transactionIdentifier = $token['transactionIdentifier'];
-            $applePay->paymentData = $token['paymentData'];
+            // Vindicia expects the paymentData to be a string
+            $applePay->paymentData = json_encode($token['paymentData']);
 
             $paymentMethod->applePay = $applePay;
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Guzzle\Http\ClientInterface;
 use InvalidArgumentException;
 use Omnipay\Common\CreditCard;
-use Omnipay\Common\NonStrippingCreditCard;
+use Omnipay\Vindicia\NonStrippingCreditCard;
 
 /**
  * Vindicia Abstract Request
@@ -1139,17 +1139,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             if (!$this->isUpdate()) {
                 $paymentMethod->type = self::PAYMENT_METHOD_PAYPAL;
             }
-        } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY && $card !== null) {
+        } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY) {
             $applePay = new stdClass();
 
-            /**
-             * @var \Omnipay\Vindicia\NonStrippingCreditCard $card
-             */
-            $applePay->paymentInstrumentName = $card->getPaymentInstrumentName();
-            $applePay->paymentNetwork = $card->getPaymentNetwork();
-            $applePay->paymentData = $card->getToken();
-            $applePay->transactionReference = $card->getApplePayTransactionReference();
-            $applePay->expirationDate = $card->getExpiryDate(self::VINDICIA_EXPIRATION_DATE_FORMAT);
+            $token = $this->getToken();
+            $applePay->paymentInstrumentName = $token['paymentMethod']['displayName'];
+            $applePay->paymentNetwork = $token['paymentMethod']['network'];
+            $applePay->paymentData = $token['paymentData'];
+            $applePay->transactionIdentifier = $token['transactionIdentifier'];
 
             $paymentMethod->applePay = $applePay;
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -867,6 +867,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     * Gets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
+     *
+     * @return array|null
+     */
+    public function getApplePayToken()
+    {
+        return $this->getParameter('applePayToken');
+    }
+
+    /**
      * The object type on which the API call will be made
      *
      * @return string
@@ -1094,6 +1104,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      * @return stdClass
      * @throws InvalidArgumentException if $paymentMethodType is not supported
      * @throws InvalidCreditCardException
+     * @psalm-suppress PossiblyInvalidArrayOffset for applePayToken object
+     * @psalm-suppress PossiblyNullArrayAccess for applePayToken object
      */
     protected function buildPaymentMethod($paymentMethodType, $addAttributes = false)
     {
@@ -1142,7 +1154,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         } elseif ($paymentMethodType === self::PAYMENT_METHOD_APPLE_PAY) {
             $applePay = new stdClass();
 
-            $token = $this->getToken();
+            $token = $this->getApplePayToken();
             $applePay->paymentInstrumentName = $token['paymentMethod']['displayName'];
             $applePay->paymentNetwork = $token['paymentMethod']['network'];
             $applePay->transactionIdentifier = $token['transactionIdentifier'];

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -9,7 +9,7 @@ namespace Omnipay\Vindicia\Message;
  * capture in one step, use the purchase function, if available.
  *
  * You may use other fields from the ApplePayPayment object to fill out billing info.
- * This request only requires the 'token' field from the ApplePayPayment object.
+ * This request only requires the 'token' field from the ApplePayPaymentToken extracted from the ApplePayPayment object.
  * 
  * Example:
  * <code>
@@ -36,11 +36,11 @@ namespace Omnipay\Vindicia\Message;
  *       'attributes' => array(
  *           'location' => 'FL'
  *       )
- *       //ApplePayPayment token extracted from ApplePayPayment object.
+ *       //ApplePayPaymentToken extracted from ApplePayPayment object.
  *       //You retrieve the ApplePayPayment object when a user authorizes a payment
  *       //using the ApplePsy payment sheet.
  *       'token' => array(
- *           //ApplePayPayment token info
+ *           //ApplePayPaymentToken object fields
  *       )
  *   ))->send();
  *
@@ -73,7 +73,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
     }
 
     /**
-     * Gets the token received from the parsed ApplePayPayment object.
+     * Gets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
      *
      * @return string|null
      */

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -3,13 +3,13 @@
 namespace Omnipay\Vindicia\Message;
 
 /**
- * After the Apple Pay payment sheet is fully loaded on the frontend. The user can authorize a payment 
+ * After the Apple Pay payment sheet is fully loaded on the frontend, the user can authorize a payment 
  * using Touch or Face ID –– this will grant access to the ApplePayPaymentToken. You can then authorize a payment
  * using this request with the ApplePayPaymentToken as a parameter along with other information needed for
  * an authorization (see AuthorizeRequest). No money will be transferred during authorization.
  * After authorizing a transaction, call capture to complete the transaction and transfer the money.
  *
- * You may use other fields from the ApplePayPayment object to fill out billing info.
+ * You may use other fields from the ApplePayPayment object to fill out billing info for a successful transaction.
  * This request only requires the 'token' field from the ApplePayPaymentToken extracted from the ApplePayPayment
  * object on the front end. Pass the extracted 'token' to the 'applePayToken' parameter of this class.
  * 
@@ -26,10 +26,8 @@ namespace Omnipay\Vindicia\Message;
  *  *    // ApplePayPaymentToken extracted from ApplePayPayment object.
  *       // You retrieve the ApplePayPayment object when a user authorizes a payment
  *       // using the ApplePay payment sheet.
- *       'applePayToken' => array(
- *           //ApplePayPaymentToken fields
- *       )
- *       // Params needed to authorize a payment can go here as well.
+ *       'applePayToken' => $apple_pay_token;
+ *       // For a successful transaction, parameters for an AuthorizeRequest are needed as well.
  *       'items' => array(
  *           array('name' => 'Item 1', 'sku' => '1', 'price' => '3.50', 'quantity' => 1),
  *           array('name' => 'Item 2', 'sku' => '2', 'price' => '9.99', 'quantity' => 2)

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+/**
+ * Authorize a transaction using an ApplePayPayment object from the Apple Pay payment sheet on frontend.
+ * No money will be transferred during authorization. After authorizing a transaction, call capture to 
+ * complete the transaction and transfer the money. If you want to do authorize and 
+ * capture in one step, use the purchase function, if available.
+ *
+ * You may use other fields from the ApplePayPayment object to fill out billing info.
+ * This request only requires the 'token' field from the ApplePayPayment object.
+ * 
+ * Example:
+ * <code>
+ *   // set up the gateway
+ *   $gateway = \Omnipay\Omnipay::create('Vindicia ApplePay');
+ *   $gateway->setUsername('your_username');
+ *   $gateway->setPassword('y0ur_p4ssw0rd');
+ *   $gateway->setTestMode(false);
+ *
+ *   // authorize the transaction
+ *   $authorizeResponse = $gateway->completeAuthorize(array(
+ *       'items' => array(
+ *           array('name' => 'Item 1', 'sku' => '1', 'price' => '3.50', 'quantity' => 1),
+ *           array('name' => 'Item 2', 'sku' => '2', 'price' => '9.99', 'quantity' => 2)
+ *       ),
+ *       'amount' => '23.48', // not necessary since items are provided
+ *       'currency' => 'USD',
+ *       'customerId' => '123456', // will be created if it doesn't already exist
+ *       'card' => array(
+ *           'postcode' => '12345'
+ *       ),
+ *       'paymentMethodId' => 'cc-123456', // this ID will be assigned to the card, which will
+ *        // be attached to the customer's account
+ *       'attributes' => array(
+ *           'location' => 'FL'
+ *       )
+ *       //ApplePayPayment token extracted from ApplePayPayment object.
+ *       //You retrieve the ApplePayPayment object when a user authorizes a payment
+ *       //using the ApplePsy payment sheet.
+ *       'token' => array(
+ *           //ApplePayPayment token info
+ *       )
+ *   ))->send();
+ *
+ *   if ($authorizeResponse->isSuccessful()) {
+ *       // Note: Your transaction ID begins with a prefix you specified in your initial
+ *       // Vindicia configuration. The ID is automatically assigned by Vindicia.
+ *       echo "Transaction id: " . $authorizeResponse->getTransactionId() . PHP_EOL;
+ *       echo "Transaction reference: " . $authorizeResponse->getTransactionReference() . PHP_EOL;
+ *       echo "The transaction risk score is: " . $authorizeResponse->getRiskScore();
+ *   } else {
+ *       // error handling
+ *   }
+ */
+
+class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
+{
+
+    /**
+     * Sets the token received from the parsed ApplePayPayment object.
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setToken($value)
+    {
+        /**
+         * @var static
+         */
+        return $this->setParameter('token', $value);
+    }
+
+    /**
+     * Gets the token received from the parsed ApplePayPayment object.
+     *
+     * @return string|null
+     */
+    public function getToken()
+    {
+        return $this->getParameter('token');
+    }
+
+    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    {
+        $this->validate('token');
+
+        return parent::getData(self::PAYMENT_METHOD_APPLE_PAY);
+    }
+
+    /**
+     * Overriding to provide a more precise return type
+     * @return AbstractResponse
+     */
+    public function send()
+    {
+        /**
+         * @var AbstractResponse
+         */
+        return parent::send();
+    }
+}

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -82,7 +82,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
      * @throws InvalidRequestException
      * @throws InvalidCreditCardException
      */
-    public function getData()
+    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
         $this->validate('applePayToken');
 

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -40,8 +40,8 @@ namespace Omnipay\Vindicia\Message;
  *       //ApplePayPaymentToken extracted from ApplePayPayment object.
  *       //You retrieve the ApplePayPayment object when a user authorizes a payment
  *       //using the ApplePsy payment sheet.
- *       'token' => array(
- *           //ApplePayPaymentToken object fields
+ *       'applePayToken' => array(
+ *           //ApplePayPaymentToken fields
  *       )
  *   ))->send();
  *
@@ -65,12 +65,12 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
      * @param array $value
      * @return static
      */
-    public function setToken($value)
+    public function setApplePayToken($value)
     {
         /**
          * @var static
          */
-        return $this->setParameter('token', $value);
+        return $this->setParameter('applePayToken', $value);
     }
 
     /**
@@ -78,14 +78,14 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
      *
      * @return array|null
      */
-    public function getToken()
+    public function getApplePayToken()
     {
-        return $this->getParameter('token');
+        return $this->getParameter('applePayToken');
     }
 
     public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
-        $this->validate('token');
+        $this->validate('applePayToken');
 
         return parent::getData(self::PAYMENT_METHOD_APPLE_PAY);
     }

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -56,6 +56,9 @@ namespace Omnipay\Vindicia\Message;
  *   } else {
  *       // error handling
  *   }
+ * 
+ * See ApplePayJS API for more documentation:
+ * @link https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api
  */
 
 class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
@@ -76,16 +79,10 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
     }
 
     /**
-     * Gets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
-     *
-     * @return array|null
+     * @throws InvalidRequestException
+     * @throws InvalidCreditCardException
      */
-    public function getApplePayToken()
-    {
-        return $this->getParameter('applePayToken');
-    }
-
-    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    public function getData()
     {
         $this->validate('applePayToken');
 

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -3,10 +3,11 @@
 namespace Omnipay\Vindicia\Message;
 
 /**
- * Authorize a transaction using an ApplePayPayment object from the Apple Pay payment sheet on frontend.
- * No money will be transferred during authorization. After authorizing a transaction, call capture to 
- * complete the transaction and transfer the money. If you want to do authorize and 
- * capture in one step, use the purchase function, if available.
+ * After the Apple Pay payment sheet is fully loaded on the frontend. The user can authorize a payment 
+ * using Touch or Face ID –– this will grant access to the ApplePayPaymentToken. You can then authorize a payment
+ *  using this request with the ApplePayPaymentToken as a parameter along with other information needed for
+ *  an authorization (see AuthorizeRequest). No money will be transferred during authorization.
+ * After authorizing a transaction, call capture to complete the transaction and transfer the money.
  *
  * You may use other fields from the ApplePayPayment object to fill out billing info.
  * This request only requires the 'token' field from the ApplePayPaymentToken extracted from the ApplePayPayment object.
@@ -59,7 +60,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
 {
 
     /**
-     * Sets the token received from the parsed ApplePayPayment object.
+     * Sets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
      *
      * @param string $value
      * @return static

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -62,7 +62,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
     /**
      * Sets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
      *
-     * @param string $value
+     * @param array $value
      * @return static
      */
     public function setToken($value)
@@ -76,7 +76,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
     /**
      * Gets the ApplePayPaymentToken received from the parsed ApplePayPayment object.
      *
-     * @return string|null
+     * @return array|null
      */
     public function getToken()
     {
@@ -88,17 +88,5 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
         $this->validate('token');
 
         return parent::getData(self::PAYMENT_METHOD_APPLE_PAY);
-    }
-
-    /**
-     * Overriding to provide a more precise return type
-     * @return AbstractResponse
-     */
-    public function send()
-    {
-        /**
-         * @var AbstractResponse
-         */
-        return parent::send();
     }
 }

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -5,12 +5,13 @@ namespace Omnipay\Vindicia\Message;
 /**
  * After the Apple Pay payment sheet is fully loaded on the frontend. The user can authorize a payment 
  * using Touch or Face ID –– this will grant access to the ApplePayPaymentToken. You can then authorize a payment
- *  using this request with the ApplePayPaymentToken as a parameter along with other information needed for
- *  an authorization (see AuthorizeRequest). No money will be transferred during authorization.
+ * using this request with the ApplePayPaymentToken as a parameter along with other information needed for
+ * an authorization (see AuthorizeRequest). No money will be transferred during authorization.
  * After authorizing a transaction, call capture to complete the transaction and transfer the money.
  *
  * You may use other fields from the ApplePayPayment object to fill out billing info.
- * This request only requires the 'token' field from the ApplePayPaymentToken extracted from the ApplePayPayment object.
+ * This request only requires the 'token' field from the ApplePayPaymentToken extracted from the ApplePayPayment
+ * object on the front end. Pass the extracted 'token' to the 'applePayToken' parameter of this class.
  * 
  * Example:
  * <code>
@@ -22,6 +23,13 @@ namespace Omnipay\Vindicia\Message;
  *
  *   // authorize the transaction
  *   $authorizeResponse = $gateway->completeAuthorize(array(
+ *  *    // ApplePayPaymentToken extracted from ApplePayPayment object.
+ *       // You retrieve the ApplePayPayment object when a user authorizes a payment
+ *       // using the ApplePay payment sheet.
+ *       'applePayToken' => array(
+ *           //ApplePayPaymentToken fields
+ *       )
+ *       // Params needed to authorize a payment can go here as well.
  *       'items' => array(
  *           array('name' => 'Item 1', 'sku' => '1', 'price' => '3.50', 'quantity' => 1),
  *           array('name' => 'Item 2', 'sku' => '2', 'price' => '9.99', 'quantity' => 2)
@@ -33,15 +41,9 @@ namespace Omnipay\Vindicia\Message;
  *           'postcode' => '12345'
  *       ),
  *       'paymentMethodId' => 'cc-123456', // this ID will be assigned to the card, which will
- *        // be attached to the customer's account
+ *                                         // be attached to the customer's account
  *       'attributes' => array(
  *           'location' => 'FL'
- *       )
- *       //ApplePayPaymentToken extracted from ApplePayPayment object.
- *       //You retrieve the ApplePayPayment object when a user authorizes a payment
- *       //using the ApplePsy payment sheet.
- *       'applePayToken' => array(
- *           //ApplePayPaymentToken fields
  *       )
  *   ))->send();
  *

--- a/src/Message/ApplePayCompleteAuthorizeRequest.php
+++ b/src/Message/ApplePayCompleteAuthorizeRequest.php
@@ -82,7 +82,7 @@ class ApplePayCompleteAuthorizeRequest extends AuthorizeRequest
      * @throws InvalidRequestException
      * @throws InvalidCreditCardException
      */
-    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    public function getData($paymentMethodType = self::PAYMENT_METHOD_APPLE_PAY)
     {
         $this->validate('applePayToken');
 

--- a/src/NonStrippingCreditCard.php
+++ b/src/NonStrippingCreditCard.php
@@ -104,8 +104,7 @@ class NonStrippingCreditCard extends CreditCard
     }
 
     /**
-     * Sets the token receieved from Apple Pay payment sheet.
-     * Includes the country, zip code, expiration date and account holder name.
+     * Sets the payment token.
      *
      * @param string $value
      * @return static
@@ -119,8 +118,7 @@ class NonStrippingCreditCard extends CreditCard
     }
 
     /**
-     * Gets the token receieved from Apple Pay payment sheet.
-     * Includes the country, zip code, expiration date and account holder name.
+     * Gets the payment token.
      *
      * @return string|null
      */

--- a/src/NonStrippingCreditCard.php
+++ b/src/NonStrippingCreditCard.php
@@ -102,28 +102,4 @@ class NonStrippingCreditCard extends CreditCard
     {
         return $this->getParameter('applePayTransactionReference');
     }
-
-    /**
-     * Sets the payment token.
-     *
-     * @param string $value
-     * @return static
-     */
-    public function setToken($value)
-    {
-        /**
-         * @var static
-         */
-        return $this->setParameter('token', $value);
-    }
-
-    /**
-     * Gets the payment token.
-     *
-     * @return string|null
-     */
-    public function getToken()
-    {
-        return $this->getParameter('token');
-    }
 }

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1188,4 +1188,25 @@ class DataFaker
             )
         ));
     }
+
+    /**
+     * The token portion of the ApplePayPayment object received from the Apple Pay payment sheet.
+     *
+     * @return string
+     */
+    public function token()
+    {
+        return array(
+            // payment data to be decrypted by payment gateway
+            'paymentData' => $this->applePayPaymentData(),
+            // card info
+            'paymentMethod' => [
+                // card brand and last four of credit card - i.e 'MasterCard 1234'
+                'displayName' => $this->paymentNetwork() . ' ' . $this->intBetween(1000, 9999),
+                'network'     => $this->paymentNetwork(),
+                'type'        => 'debit'
+            ],
+            'transactionIdentifier' => $this->randomCharacters(self::DIGITS . self::ALPHABET_UPPER, 17)
+        );
+    }
 }

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1195,7 +1195,7 @@ class DataFaker
      *
      * @return array
      */
-    public function token()
+    public function applePayToken()
     {
         return array(
             // payment data to be decrypted by payment gateway

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1162,8 +1162,8 @@ class DataFaker
     /**
      * The paymentData portion of the token taken from the ApplePayPayment object received from
      * the Apple Pay payment sheet.
-     * We need to use json encode it so that its parsed as a string instead of an array to
-     *  match token object.
+     * We need to json encode it so that it's parsed as a string instead of an array to
+     * match token object.
      *
      * @return string
      */

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1193,7 +1193,7 @@ class DataFaker
     /**
      * The token portion of the ApplePayPayment object received from the Apple Pay payment sheet.
      *
-     * @return string
+     * @return array
      */
     public function token()
     {
@@ -1201,12 +1201,12 @@ class DataFaker
             // payment data to be decrypted by payment gateway
             'paymentData' => $this->applePayPaymentData(),
             // card info
-            'paymentMethod' => [
+            'paymentMethod' => array(
                 // card brand and last four of credit card - i.e 'MasterCard 1234'
                 'displayName' => $this->paymentNetwork() . ' ' . $this->intBetween(1000, 9999),
                 'network'     => $this->paymentNetwork(),
                 'type'        => 'debit'
-            ],
+            ),
             'transactionIdentifier' => $this->randomCharacters(self::DIGITS . self::ALPHABET_UPPER, 17)
         );
     }

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1160,6 +1160,16 @@ class DataFaker
     }
 
     /**
+     * Returns a card token
+     *
+     * @return string
+     */
+    public function token()
+    {
+        return $this->randomCharacters(self::DIGITS . self::ALPHABET_UPPER, 17);
+    }
+
+    /**
      * The paymentData portion of the token taken from the ApplePayPayment object received from
      * the Apple Pay payment sheet.
      * We need to use json encode it so that its parsed as a string instead of an array to

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1160,16 +1160,6 @@ class DataFaker
     }
 
     /**
-     * Returns a card token
-     *
-     * @return string
-     */
-    public function token()
-    {
-        return $this->randomCharacters(self::DIGITS . self::ALPHABET_UPPER, 17);
-    }
-
-    /**
      * The paymentData portion of the token taken from the ApplePayPayment object received from
      * the Apple Pay payment sheet.
      * We need to use json encode it so that its parsed as a string instead of an array to

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1160,13 +1160,14 @@ class DataFaker
     }
 
     /**
-     * The token received from Apple Pay payment sheet.
-     * Includes the country, zip code, expiration date and account holder name.
-     * Need to use json encode so that it is parsed as a string instead of an array to match token object.
+     * The paymentData portion of the token taken from the ApplePayPayment object received from
+     * the Apple Pay payment sheet.
+     * We need to use json encode it so that its parsed as a string instead of an array to
+     *  match token object.
      *
      * @return string
      */
-    public function token()
+    public function applePayPaymentData()
     {
         return json_encode(array(
             'version' => $this->randomCharacters(self::ALPHABET_UPPER . self::DIGITS, $this->intBetween(1, 5)),

--- a/tests/ApplePayGatewayTest.php
+++ b/tests/ApplePayGatewayTest.php
@@ -25,6 +25,7 @@ class ApplePayGatewayTest extends GatewayTestCase
         $this->merchantIdentifier = $this->faker->transactionId();
         $this->displayName = $this->faker->username();
         $this->applicationUrl = $this->faker->url();
+        $this->token = $this->faker->applePayToken();
     }
 
     /**
@@ -128,6 +129,21 @@ class ApplePayGatewayTest extends GatewayTestCase
     /**
      * @return void
      */
+    public function testCompleteAuthorize()
+    {
+        $request = $this->gateway->completeAuthorize(
+            array(
+                'applePayToken' => $this->token
+            )
+        );
+
+        $this->assertInstanceOf('Omnipay\Vindicia\Message\ApplePayCompleteAuthorizeRequest', $request);
+        $this->assertSame($this->token, $request->getApplePayToken());
+    }
+
+    /**
+     * @return void
+     */
     public function testUpdatePaymentMethod()
     {
         $card = $this->faker->card();
@@ -144,6 +160,23 @@ class ApplePayGatewayTest extends GatewayTestCase
         $this->assertInstanceOf('Omnipay\Vindicia\Message\CreatePaymentMethodRequest', $request);
         $this->assertSameCard($card, $request->getCard());
         $this->assertSame($customerId, $request->getCustomerId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testVoid()
+    {
+        $transactionId = $this->faker->transactionId();
+
+        $request = $this->gateway->void(
+            array(
+                'transactionId' => $transactionId
+            )
+        );
+
+        $this->assertInstanceOf('Omnipay\Vindicia\Message\VoidRequest', $request);
+        $this->assertSame($transactionId, $request->getTransactionId());
     }
 
     /**

--- a/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
@@ -19,8 +19,8 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
         $this->keyCertPassword = $this->faker->password();
 
         // Request parameters.
-        // Apple Pay token.
-        $this->token = $this->faker->token();
+        // Apple Pay Payment token.
+        $this->token = $this->faker->applePayToken();
         // Params needed to initialize AuthorizeRequest.
         $this->currency = $this->faker->currency();
         $this->amount = $this->faker->monetaryAmount($this->currency);
@@ -40,7 +40,7 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
         $this->request = new ApplePayCompleteAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
-                'token' => $this->token,
+                'applePayToken' => $this->token,
                 'amount' => $this->amount,
                 'currency' => $this->currency,
                 'card' => $this->card,
@@ -64,7 +64,7 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
      */
     public function testToken()
     {
-        $data = $this->request->getToken();
+        $data = $this->request->getApplePayToken();
         $this->assertSame($this->token, $data);
     }
 
@@ -73,7 +73,7 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
      */
     public function testGetData()
     {
-        $this->request->setToken($this->token);
+        $this->request->setApplePayToken($this->token);
         $data = $this->request->getData();
 
         $this->assertSame($this->token['paymentMethod']['displayName'], $data['transaction']->sourcePaymentMethod->applePay->paymentInstrumentName);

--- a/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
@@ -62,7 +62,7 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
     /**
      * @return void
      */
-    public function testToken()
+    public function testApplePayToken()
     {
         $data = $this->request->getApplePayToken();
         $this->assertSame($this->token, $data);

--- a/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
@@ -19,12 +19,42 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
         $this->keyCertPassword = $this->faker->password();
 
         // Request parameters.
-        $this->token = $this->faker->applePayPaymentToken();
+        // Apple Pay token.
+        $this->token = $this->faker->token();
+        // Params needed to initialize AuthorizeRequest.
+        $this->currency = $this->faker->currency();
+        $this->amount = $this->faker->monetaryAmount($this->currency);
+        $this->customerId = $this->faker->customerId();
+        $this->customerReference = $this->faker->customerReference();
+        $this->card = $this->faker->card();
+        $this->paymentMethodId = $this->faker->paymentMethodId();
+        $this->paymentMethodReference = $this->faker->paymentMethodReference();
+        $this->statementDescriptor = $this->faker->statementDescriptor();
+        $this->ip = $this->faker->ipAddress();
+        $this->attributes = $this->faker->attributesAsArray();
+        $this->taxClassification = $this->faker->taxClassification();
+        $this->minChargebackProbability = $this->faker->chargebackProbability();
+        $this->name = $this->faker->name();
+        $this->email = $this->faker->email();
 
         $this->request = new ApplePayCompleteAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
-                'token' => $this->token
+                'token' => $this->token,
+                'amount' => $this->amount,
+                'currency' => $this->currency,
+                'card' => $this->card,
+                'paymentMethodId' => $this->paymentMethodId,
+                'paymentMethodReference' => $this->paymentMethodReference,
+                'customerId' => $this->customerId,
+                'customerReference' => $this->customerReference,
+                'name' => $this->name,
+                'email' => $this->email,
+                'statementDescriptor' => $this->statementDescriptor,
+                'ip' => $this->ip,
+                'attributes' => $this->attributes,
+                'taxClassification' => $this->taxClassification,
+                'minChargebackProbability' => $this->minChargebackProbability
             )
         );
     }
@@ -46,6 +76,9 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
         $this->request->setToken($this->token);
         $data = $this->request->getData();
 
-        $this->assertSame($this->token, $data['token']);
+        $this->assertSame($this->token['paymentMethod']['displayName'], $data['transaction']->sourcePaymentMethod->applePay->paymentInstrumentName);
+        $this->assertSame($this->token['paymentMethod']['network'], $data['transaction']->sourcePaymentMethod->applePay->paymentNetwork);
+        $this->assertSame($this->token['transactionIdentifier'], $data['transaction']->sourcePaymentMethod->applePay->transactionIdentifier);
+        $this->assertSame($this->token['paymentData'], $data['transaction']->sourcePaymentMethod->applePay->paymentData);
     }
 }

--- a/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
@@ -79,6 +79,6 @@ class ApplePayCompleteAuthorizeRequestTest extends TestCase
         $this->assertSame($this->token['paymentMethod']['displayName'], $data['transaction']->sourcePaymentMethod->applePay->paymentInstrumentName);
         $this->assertSame($this->token['paymentMethod']['network'], $data['transaction']->sourcePaymentMethod->applePay->paymentNetwork);
         $this->assertSame($this->token['transactionIdentifier'], $data['transaction']->sourcePaymentMethod->applePay->transactionIdentifier);
-        $this->assertSame($this->token['paymentData'], $data['transaction']->sourcePaymentMethod->applePay->paymentData);
+        $this->assertSame(json_encode($this->token['paymentData']), $data['transaction']->sourcePaymentMethod->applePay->paymentData);
     }
 }

--- a/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
+++ b/tests/Message/ApplePayCompleteAuthorizeRequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+use Omnipay\Vindicia\TestFramework\DataFaker;
+use Omnipay\Tests\TestCase;
+
+class ApplePayCompleteAuthorizeRequestTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        // Gateway parameters.
+        $this->faker = new DataFaker();
+        $this->pemCertPath = $this->faker->path();
+        $this->keyCertPath = $this->faker->path();
+        $this->keyCertPassword = $this->faker->password();
+
+        // Request parameters.
+        $this->token = $this->faker->applePayPaymentToken();
+
+        $this->request = new ApplePayCompleteAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'token' => $this->token
+            )
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testToken()
+    {
+        $data = $this->request->getToken();
+        $this->assertSame($this->token, $data);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetData()
+    {
+        $this->request->setToken($this->token);
+        $data = $this->request->getData();
+
+        $this->assertSame($this->token, $data['token']);
+    }
+}

--- a/tests/Message/FetchPaymentMethodRequestTest.php
+++ b/tests/Message/FetchPaymentMethodRequestTest.php
@@ -19,7 +19,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
         $this->paymentMethodId = $this->faker->paymentMethodId();
         $this->paymentInstrumentName = $this->faker->paymentInstrumentName();
         $this->paymentNetwork = $this->faker->paymentNetwork();
-        $this->paymentData = $this->faker->token();
+        $this->paymentData = $this->faker->applePayPaymentData();
         $this->transactionReference = $this->faker->transactionId();
 
         $this->request = new FetchPaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest());

--- a/tests/Mock/ApplePayCompleteAuthorizeRequestSuccess.xml
+++ b/tests/Mock/ApplePayCompleteAuthorizeRequestSuccess.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" 
+    xmlns:vin="http://soap.vindicia.com/v18_0/Vindicia" 
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" 
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <authCaptureResponse xmlns="http://soap.vindicia.com/v21_0/Transaction">
+            <return xmlns="" xsi:type="vin:Return">
+                <returnCode xsi:type="vin:ReturnCode">200</returnCode>
+                <soapId xsi:type="xsd:string">1234567890abcdef1234567890abcdef</soapId>
+                <returnString xsi:type="xsd:string">OK</returnString>
+            </return>
+            <transaction xmlns="" xsi:type="vin:Transaction">
+                <VID xmlns="" xsi:type="xsd:string">1234567890abcdef1234567890abcdef</VID>
+                <amount xmlns="" xsi:type="xsd:decimal">[AMOUNT]</amount>
+                <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
+                <divisionNumber xmlns="" xsi:type="xsd:string">12345</divisionNumber>
+                <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
+                <timestamp xmlns="" xsi:type="xsd:dateTime">2016-11-08T07:41:58-08:00</timestamp>
+                <account xsi:type="vin:Account">
+                    <VID xmlns="" xsi:type="xsd:string">9876543210fedcba9876543210fedcba</VID>
+                    <merchantAccountId xmlns="" xsi:type="xsd:string">[CUSTOMER_ID]</merchantAccountId>
+                    <emailAddress xsi:type="xsd:string">vin_Account_emailAddress</emailAddress>
+                    <emailTypePreference xsi:type="vin:EmailPreference">html</emailTypePreference>
+                    <name xsi:type="xsd:string">Abcdefg Abcdefg</name>
+                    <paymentMethods xsi:type="vin:PaymentMethod">
+                        <VID xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_REFERENCE]</VID>
+                        <type xsi:type="vin:PaymentMethodType">ApplePay</type>
+                        <applePay xsi:type="vin:ApplePay">
+                            <paymentInstrumentName xsi:type="xsd:string">[PAYMENT_INSTRUMENT_NAME]</paymentInstrumentName>
+                            <paymentNetwork xsi:type="xsd:string">[PAYMENT_NETWORK]</paymentNetwork>
+                            <transactionIdentifier xsi:type="xsd:string">[TRANSACTION_REFERENCE]</transactionIdentifier>
+                            <paymentData xsi:type="xsd:string">[PAYMENT_DATA]</paymentData>
+                            <expirationDate xsi:type="xsd:string">000001234567890abcdef</expirationDate>
+                        </applePay>
+                        <accountHolderName xsi:type="xsd:string">attributeName</accountHolderName>
+                        <billingAddress xsi:type="vin:Address">
+                            <VID xmlns="" xsi:type="xsd:string">fdecba9876543210fdecba9876543210</VID>
+                            <addr1 xsi:type="xsd:string">123 Abcd Ave</addr1>
+                            <city xsi:type="xsd:string">Abcd</city>
+                            <district xsi:type="xsd:string">AB</district>
+                            <postalCode xmlns="" xsi:type="xsd:string">[POSTCODE]</postalCode>
+                            <country xmlns="" xsi:type="xsd:string">[COUNTRY]</country>
+                        </billingAddress>
+                        <merchantPaymentMethodId xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_ID]</merchantPaymentMethodId>
+                        <sortOrder xsi:type="xsd:int">0</sortOrder>
+                        <active xsi:type="xsd:boolean">1</active>
+                    </paymentMethods>
+                </account>
+                <sourcePaymentMethod xsi:type="vin:PaymentMethod">
+                    <VID xsi:type="xsd:string">0123456789fedcba0123456789fedcba</VID>
+                    <type xsi:type="vin:PaymentMethodType">ApplePay</type>
+                    <applePay xsi:type="vin:ApplePay">
+                        <paymentInstrumentName xsi:type="xsd:string">[PAYMENT_INSTRUMENT_NAME]</paymentInstrumentName>
+                        <paymentNetwork xsi:type="xsd:string">[PAYMENT_NETWORK]</paymentNetwork>
+                        <transactionIdentifier xsi:type="xsd:string">[TRANSACTION_REFERENCE]</transactionIdentifier>
+                        <paymentData xsi:type="xsd:string">[PAYMENT_DATA]</paymentData>
+                        <expirationDate xsi:type="xsd:string">000001234567890abcdef</expirationDate>
+                    </applePay>
+                    <accountHolderName xsi:type="xsd:string">attributeName</accountHolderName>
+                    <billingAddress xsi:type="vin:Address">
+                        <VID xsi:type="xsd:string">0123456789fedcba0123456789fedcba</VID>
+                        <postalCode xmlns="" xsi:type="xsd:string">[POSTCODE]</postalCode>
+                        <country xmlns="" xsi:type="xsd:string">[COUNTRY]</country>
+                    </billingAddress>
+                    <merchantPaymentMethodId xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_ID]</merchantPaymentMethodId>
+                    <sortOrder xsi:type="xsd:int">0</sortOrder>
+                    <active xsi:type="xsd:boolean">0</active>
+                </sourcePaymentMethod>
+                <statusLog xsi:type="vin:TransactionStatus">
+               <status xsi:type="vin:TransactionStatusType">Authorized</status>
+               <timestamp xsi:type="xsd:dateTime">2018-07-26T09:42:47-07:00</timestamp>
+               <paymentMethodType xsi:type="vin:PaymentMethodType">ApplePay</paymentMethodType>
+               <applePayStatus xsi:type="vin:TransactionStatusApplePay">
+                  <authCode xsi:type="xsd:string">000</authCode>
+               </applePayStatus>
+               <vinAVS xsi:type="vin:AVSMatchType">FullMatch</vinAVS>
+            </statusLog>
+            <statusLog xsi:type="vin:TransactionStatus">
+               <status xsi:type="vin:TransactionStatusType">New</status>
+               <timestamp xsi:type="xsd:dateTime">2018-07-26T09:42:46-07:00</timestamp>
+               <paymentMethodType xsi:type="vin:PaymentMethodType">ApplePay</paymentMethodType>
+               <applePayStatus xsi:type="vin:TransactionStatusApplePay">
+                  <authCode xsi:type="xsd:string">000</authCode>
+               </applePayStatus>
+            </statusLog>
+                <paymentProcessor xsi:type="xsd:string">ProcessorName</paymentProcessor>
+                <paymentProcessorTransactionId xsi:type="xsd:string">123XYZ</paymentProcessorTransactionId>
+                <transactionItems xsi:type="vin:TransactionItem">
+                    <sku xmlns="" xsi:type="xsd:string">[SKU]</sku>
+                    <indexNumber xsi:type="xsd:int">1</indexNumber>
+                    <itemType xsi:type="vin:TransactionItemType">Purchase</itemType>
+                    <name xsi:type="xsd:string">For Validation Only - no charge to you</name>
+                    <price xmlns="" xsi:type="xsd:decimal">[AMOUNT]</price>
+                    <quantity xsi:type="xsd:decimal">1</quantity>
+                    <taxClassification xmlns="" xsi:type="xsd:string">[TAX_CLASSIFICATION]</taxClassification>
+                    <taxType xsi:type="xsd:string">Exclusive Sales</taxType>
+                    <subtotal xmlns="" xsi:type="xsd:decimal">[AMOUNT]</subtotal>
+                    <total xmlns="" xsi:type="xsd:decimal">[AMOUNT]</total>
+                </transactionItems>
+                <transactionItems xsi:type="vin:TransactionItem">
+                    <sku xsi:type="xsd:string">Total Tax</sku>
+                    <indexNumber xsi:type="xsd:int">2</indexNumber>
+                    <itemType xsi:type="vin:TransactionItemType">Purchase</itemType>
+                    <name xsi:type="xsd:string">Total Tax</name>
+                    <price xsi:type="xsd:decimal">0</price>
+                    <quantity xsi:type="xsd:decimal">1</quantity>
+                    <taxClassification xmlns="" xsi:type="xsd:string">[TAX_CLASSIFICATION]</taxClassification>
+                    <taxType xsi:type="xsd:string">Exclusive Sales</taxType>
+                    <discount xsi:type="xsd:decimal">0</discount>
+                    <subtotal xsi:type="xsd:decimal">0</subtotal>
+                    <total xsi:type="xsd:decimal">0</total>
+                </transactionItems>
+                <salesTaxAddress xsi:type="vin:Address">
+                    <VID xmlns="" xsi:type="xsd:string">fdecba9876543210fdecba9876543210</VID>
+                    <postalCode xmlns="" xsi:type="xsd:string">[POSTCODE]</postalCode>
+                    <country xmlns="" xsi:type="xsd:string">[COUNTRY]</country>
+                </salesTaxAddress>
+              <nameValues xmlns="" xsi:type="vin:NameValuePair">
+                <name xmlns="" xsi:type="xsd:string">[ATTRIBUTE_1_NAME]</name>
+                <value xmlns="" xsi:type="xsd:string">[ATTRIBUTE_1_VALUE]</value>
+              </nameValues>
+            <nameValues xmlns="" xsi:type="vin:NameValuePair">
+                <name xmlns="" xsi:type="xsd:string">[ATTRIBUTE_2_NAME]</name>
+                <value xmlns="" xsi:type="xsd:string">[ATTRIBUTE_2_VALUE]</value>
+            </nameValues>
+            </transaction>
+            <score xmlns="" xsi:type="xsd:int">-1</score>
+        </authCaptureResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/tests/NonStrippingCreditCardTest.php
+++ b/tests/NonStrippingCreditCardTest.php
@@ -63,14 +63,4 @@ class NonStrippingCreditCardTest extends TestCase
         $this->assertSame($this->card, $this->card->setApplePayTransactionReference($applePayTransactionReference));
         $this->assertSame($applePayTransactionReference, $this->card->getApplePayTransactionReference());
     }
-
-    /**
-     * @return void
-     */
-    public function testToken()
-    {
-        $token = $this->faker->token();
-        $this->assertSame($this->card, $this->card->setToken($token));
-        $this->assertSame($token, $this->card->getToken());
-    }
 }


### PR DESCRIPTION
- Updates `Message\AbstractRequest` for ApplePay completeAuthorize compatibility.
- Adds new `ApplePayCompleteAuthorizeRequest` file.
- Adds tests and mockfile for `ApplePayCompleteAuthorizeRequest`.
- Changed NonstrippingCreditCard's comment for token. 
_(Previous token is actually paymentData that is apart of the Apple Pay token.)_
