### PR TITLE
Modifies getSoapId to return null

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -553,7 +553,8 @@ class Response extends AbstractResponse
         if (isset($this->data->return)) {
             return $this->data->return->soapId;
         }
-        throw new InvalidResponseException('Response has no soap id.');
+
+        return null;
     }
 
     /**

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -546,7 +546,7 @@ class Response extends AbstractResponse
     /**
      * Return the soap ID from the soap response.
      *
-     * @return string
+     * @return string|null
      */
     public function getSoapId()
     {


### PR DESCRIPTION
This PR changes `Response::getSoapId()` to return null instead of throwing an error.