### PR TITLE
Allow a subscription cancellation reason to be set and retrieved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
         - COMPOSER='composer-psalm.json'
 install: composer install
 script: make $TEST_SUITE
+dist: trusty
 notifications:
   email: false
   slack:

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -25,7 +25,9 @@
     },
     "require": {
         "omnipay/common": "~2.0",
-        "vimeo/payment-gateway-logger": "^1.0"
+        "vimeo/payment-gateway-logger": "^1.0",
+        "composer/ca-bundle": "^1.1",
+        "ext-soap": "*"
     },
     "require-dev": {
         "omnipay/tests": "~2.0",

--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -15,8 +15,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * subscriptionId or subscriptionReference is required.
  * - cancelReason: The reason that the subscription was canceled (optional). Possible values are
  * documented by Vindicia here. Only the reason code needs to be specified:
- * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
- * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+ * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+ * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
  * Canceling%2520AutoBills%7C_____1
  *
  * Example:

--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -14,10 +14,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * - subscriptionReference: The gateway's identifier for the subscription to be canceled. Either
  * subscriptionId or subscriptionReference is required.
  * - cancelReason: The reason that the subscription was canceled (optional). Possible values are
- * documented by Vindicia here. Only the reason code needs to be specified:
- * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
- * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
- * Canceling%2520AutoBills%7C_____1
+ * documented by Vindicia, @see setCancelReason.
  *
  * Example:
  * <code>
@@ -117,6 +114,14 @@ class CancelSubscriptionRequest extends AbstractRequest
 
     /**
      * Set the reason the subscription was canceled
+     *
+     * Possible values:
+     *
+     * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+     * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520 \
+     * Canceling%2520AutoBills%7C_____1
+     *
+     * Only the "reason code" should be specified.
      *
      * @param string $value
      * @return static

--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -13,6 +13,11 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * or subscriptionReference is required.
  * - subscriptionReference: The gateway's identifier for the subscription to be canceled. Either
  * subscriptionId or subscriptionReference is required.
+ * - cancelReason: The reason that the subscription was canceled (optional). Possible values are
+ * documented by Vindicia here. Only the reason code needs to be specified:
+ * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+ * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+ * Canceling%2520AutoBills%7C_____1
  *
  * Example:
  * <code>
@@ -101,6 +106,27 @@ use Omnipay\Common\Exception\InvalidRequestException;
 class CancelSubscriptionRequest extends AbstractRequest
 {
     /**
+     * Gets the reason the subscription was canceled
+     *
+     * @return null|string
+     */
+    public function getCancelReason()
+    {
+        return $this->getParameter('cancelReason');
+    }
+
+    /**
+     * Set the reason the subscription was canceled
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setCancelReason($value)
+    {
+        return $this->setParameter('cancelReason', $value);
+    }
+
+    /**
      * The name of the function to be called in Vindicia's API
      *
      * @vreturn string
@@ -136,7 +162,7 @@ class CancelSubscriptionRequest extends AbstractRequest
             'force' => true,
             'settle' => false,
             'sendCancellationNotice' => false,
-            'cancelReasonCode' => null
+            'cancelReasonCode' => $this->getCancelReason()
         );
     }
 }

--- a/src/Message/CancelSubscriptionsRequest.php
+++ b/src/Message/CancelSubscriptionsRequest.php
@@ -24,8 +24,8 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * provided, ALL of the user's subscriptions will be canceled.
  * - cancelReason: The reason that the subscriptions were canceled (optional). Possible values are
  * documented by Vindicia here. Only the reason code needs to be specified:
- * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
- * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+ * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+ * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
  * Canceling%2520AutoBills%7C_____1
  *
  * Example:

--- a/src/Message/CancelSubscriptionsRequest.php
+++ b/src/Message/CancelSubscriptionsRequest.php
@@ -22,6 +22,11 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * - subscriptionReferences: Array of references (the gateway's identifiers) of the
  * subscriptions to be canceled. If neither subscriptionIds nor subscriptionReferences are
  * provided, ALL of the user's subscriptions will be canceled.
+ * - cancelReason: The reason that the subscriptions were canceled (optional). Possible values are
+ * documented by Vindicia here. Only the reason code needs to be specified:
+ * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+ * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+ * Canceling%2520AutoBills%7C_____1
  *
  * Example:
  * <code>
@@ -175,6 +180,27 @@ class CancelSubscriptionsRequest extends AbstractRequest
         return $this->setParameter('subscriptionReferences', $value);
     }
 
+    /**
+     * Gets the reason the subscription was canceled
+     *
+     * @return null|string
+     */
+    public function getCancelReason()
+    {
+        return $this->getParameter('cancelReason');
+    }
+
+    /**
+     * Set the reason the subscription was canceled
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setCancelReason($value)
+    {
+        return $this->setParameter('cancelReason', $value);
+    }
+
     public function getData()
     {
         $customerId = $this->getCustomerId();
@@ -212,7 +238,7 @@ class CancelSubscriptionsRequest extends AbstractRequest
             'action' => $this->getFunction(),
             'force' => true,
             'disentitle' => false,
-            'cancelReasonCode' => null
+            'cancelReasonCode' => $this->getCancelReason()
         );
     }
 }

--- a/src/Message/CancelSubscriptionsRequest.php
+++ b/src/Message/CancelSubscriptionsRequest.php
@@ -23,10 +23,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  * subscriptions to be canceled. If neither subscriptionIds nor subscriptionReferences are
  * provided, ALL of the user's subscriptions will be canceled.
  * - cancelReason: The reason that the subscriptions were canceled (optional). Possible values are
- * documented by Vindicia here. Only the reason code needs to be specified:
- * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
- * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
- * Canceling%2520AutoBills%7C_____1
+ * documented by Vindicia, @see CancelSubscriptionRequest::setCancelReason.
  *
  * Example:
  * <code>

--- a/src/Message/FetchSubscriptionRequest.php
+++ b/src/Message/FetchSubscriptionRequest.php
@@ -78,6 +78,7 @@ use Omnipay\Common\Exception\InvalidRequestException;
  *   if ($subscriptionResponse->isSuccessful()) {
  *       echo "Subscription id: " . $subscriptionResponse->getSubscriptionId() . PHP_EOL;
  *       echo "Subscription reference: " . $subscriptionResponse->getSubscriptionReference() . PHP_EOL;
+ *       echo "Subscription cancel reason: " . $subscriptionResponse->getSubscriptionCancelReason() . PHP_EOL;
  *   } else {
  *       // error handling
  *   }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -621,10 +621,8 @@ class Response extends AbstractResponse
     /**
      * Get the reason the subscription was canceled
      *
-     * One of the reason codes documented here by Vindicia will be returned:
-     * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
-     * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
-     * Canceling%2520AutoBills%7C_____1
+     * One of the reason codes documented by Vindicia will be returned.
+     * @see CancelSubscriptionRequest::setCancelReason.
      *
      * The value can be set by Vindicia or by the merchant. If it is not set, null will be returned.
      *

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -622,8 +622,8 @@ class Response extends AbstractResponse
      * Get the reason the subscription was canceled
      *
      * One of the reason codes documented here by Vindicia will be returned:
-     * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
-     * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+     * https://www.vindicia.com/documents/1800ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+     * _with.htm%3FTocPath%3DCashBox1800ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
      * Canceling%2520AutoBills%7C_____1
      *
      * The value can be set by Vindicia or by the merchant. If it is not set, null will be returned.

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -626,7 +626,7 @@ class Response extends AbstractResponse
      * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
      * Canceling%2520AutoBills%7C_____1
      *
-     * The value can be set by Vindicia or by the merchant.
+     * The value can be set by Vindicia or by the merchant. If it is not set, null will be returned.
      *
      * @return string|null
      */

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -619,6 +619,27 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Get the reason the subscription was canceled
+     *
+     * One of the reason codes documented here by Vindicia will be returned:
+     * https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills\
+     * _with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520\
+     * Canceling%2520AutoBills%7C_____1
+     *
+     * The value can be set by Vindicia or by the merchant.
+     *
+     * @return string|null
+     */
+    public function getSubscriptionCancelReason()
+    {
+        $subscription = $this->getSubscription();
+        if ($subscription) {
+            return $subscription->getCancelReason();
+        }
+        return null;
+    }
+
+    /**
      * Override to set return type correctly
      *
      * @return AbstractRequest

--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -345,6 +345,7 @@ class ObjectHelper
             'billingState' => isset($object->billingState) ? $object->billingState : null,
             'startTime' => isset($object->startTimestamp) ? $object->startTimestamp : null,
             'endTime' => isset($object->endTimestamp) ? $object->endTimestamp : null,
+            'cancelReason' => isset($object->cancelReason->reason_code) ? $object->cancelReason->reason_code : null,
             'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null
         ));
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -577,6 +577,27 @@ class Subscription
     }
 
     /**
+     * Gets the reason the subscription was canceled
+     *
+     * @return null|string
+     */
+    public function getCancelReason()
+    {
+        return $this->getParameter('cancelReason');
+    }
+
+    /**
+     * Set the reason the subscription was canceled
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setCancelReason($value)
+    {
+        return $this->setParameter('cancelReason', $value);
+    }
+
+    /**
      * A list of attributes
      *
      * @return AttributeBag|null

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -1112,6 +1112,16 @@ class DataFaker
     }
 
     /**
+     * Return a subscription cancel reason
+     *
+     * @return string
+     */
+    public function subscriptionCancelReason()
+    {
+        return (string) $this->intBetween(0, 9999);
+    }
+
+    /**
      * Return a payment instrument name.
      *
      * @return string

--- a/tests/Message/CancelSubscriptionsRequestTest.php
+++ b/tests/Message/CancelSubscriptionsRequestTest.php
@@ -23,13 +23,15 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
         }
         $this->customerId = $this->faker->customerId();
         $this->customerReference = $this->faker->customerReference();
+        $this->cancelReason = $this->faker->subscriptionCancelReason();
 
         $this->request = new CancelSubscriptionsRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
                 'customerId' => $this->customerId,
                 'customerReference' => $this->customerReference,
-                'subscriptionIds' => $this->subscriptionIds
+                'subscriptionIds' => $this->subscriptionIds,
+                'cancelReason' => $this->cancelReason
             )
         );
 
@@ -90,6 +92,18 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testCancelReason()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\CancelSubscriptionRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCancelReason($this->cancelReason));
+        $this->assertSame($this->cancelReason, $request->getCancelReason());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetData()
     {
         $data = $this->request->getData();
@@ -104,7 +118,7 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
         $this->assertSame('stopAutoBilling', $data['action']);
         $this->assertFalse($data['disentitle']);
         $this->assertTrue($data['force']);
-        $this->assertNull($data['cancelReasonCode']);
+        $this->assertSame($this->cancelReason, $data['cancelReasonCode']);
     }
 
     /**
@@ -126,7 +140,7 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
         $this->assertSame('stopAutoBilling', $data['action']);
         $this->assertFalse($data['disentitle']);
         $this->assertTrue($data['force']);
-        $this->assertNull($data['cancelReasonCode']);
+        $this->assertSame($this->cancelReason, $data['cancelReasonCode']);
     }
 
     /**
@@ -145,7 +159,7 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
         $this->assertSame('stopAutoBilling', $data['action']);
         $this->assertFalse($data['disentitle']);
         $this->assertTrue($data['force']);
-        $this->assertNull($data['cancelReasonCode']);
+        $this->assertSame($this->cancelReason, $data['cancelReasonCode']);
     }
 
     /**

--- a/tests/Mock/CancelSubscriptionSuccess.xml
+++ b/tests/Mock/CancelSubscriptionSuccess.xml
@@ -130,6 +130,10 @@
         </nameValues>
         <subscriptionBalance xmlns="" xsi:type="xsd:decimal">0</subscriptionBalance>
         <statementFormat xmlns="" xsi:type="vin:StatementFormat">DoNotSend</statementFormat>
+        <cancelReason xmlns="" xsi:type="vin:CancelReason">
+          <reason_code xmlns="" xsi:type="xsd:string">[CANCEL_REASON]</reason_code>
+          <description xmlns="" xsi:type="xsd:string">Merchant:  Generic Cancel (Other)</description>
+        </cancelReason>
       </autobill>
     </cancelResponse>
   </soap:Body>

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -257,6 +257,16 @@ class SubscriptionTest extends TestCase
     /**
      * @return void
      */
+    public function testCancelReason()
+    {
+        $cancelReason = $this->faker->subscriptionCancelReason();
+        $this->assertSame($this->subscription, $this->subscription->setCancelReason($cancelReason));
+        $this->assertSame($cancelReason, $this->subscription->getCancelReason());
+    }
+
+    /**
+     * @return void
+     */
     public function testBillingDay()
     {
         $billingDay = $this->faker->intBetween(1, 31);

--- a/tests/TestFramework/DataFakerTest.php
+++ b/tests/TestFramework/DataFakerTest.php
@@ -824,4 +824,14 @@ class DataFakerTest extends TestCase
         $this->assertGreaterThanOrEqual(-2, $score);
         $this->assertLessThanOrEqual(100, $score);
     }
+
+    /**
+     * @return void
+     */
+    public function testCancelReason()
+    {
+        $cancelReason = $this->faker->subscriptionCancelReason();
+        $this->assertTrue(is_string($cancelReason));
+        $this->assertGreaterThanOrEqual(0, (int) $cancelReason);
+    }
 }


### PR DESCRIPTION
Vindicia subscriptions can have a cancellation reason when they get canceled. Sometimes, Vindicia will specify the reason. The merchant can also specify the reason if they make a call to cancel the subscription.

This PR adds support for setting and retrieving the cancel reason to this library.

Vindicia docs about cancel reasons: https://www.vindicia.com/documents/1800APIGuideHTML5/Default.htm#APIGuide/CancelReason_Subobject1.htm%3FTocPath%3DCashBox1800APIGuide%7C4%2520The%2520AutoBill%2520Object%7CAutoBill%2520Subobjects%7C_____4

And here are the possible values: https://www.vindicia.com/documents/2500ProgGuideHTML5/Default.htm#ProgGuide/Canceling_AutoBills_with.htm%3FTocPath%3DCashBox2500ProgGuide%7C5%2520Working%2520with%2520AutoBills%7C5.3%2520Canceling%2520AutoBills%7C_____1