### PR TITLE
Allow custom merchant product ID in success response mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
         - COMPOSER='composer-psalm.json'
 install: composer install
 script: make $TEST_SUITE
+dist: trusty
 notifications:
   email: false
   slack:

--- a/tests/Mock/CreateSubscriptionSuccess.xml
+++ b/tests/Mock/CreateSubscriptionSuccess.xml
@@ -82,7 +82,7 @@
           <index xmlns="" xsi:type="xsd:int">0</index>
           <product xmlns="" xsi:type="vin:Product">
             <VID xmlns="" xsi:type="xsd:string">fabcdef12340987651234098765fabcdef</VID>
-            <merchantProductId xmlns="" xsi:type="xsd:string">[ITEM_MERCHANT_PRODUCT_ID]</merchantProductId>
+            <merchantProductId xmlns="" xsi:type="xsd:string">[PRODUCT_ID]</merchantProductId>
             <status xmlns="" xsi:type="vin:ProductStatus">Active</status>
             <taxClassification xmlns="" xsi:type="xsd:string">TaxExempt</taxClassification>
             <defaultBillingPlan xmlns="" xsi:type="vin:BillingPlan">

--- a/tests/Mock/CreateSubscriptionSuccess.xml
+++ b/tests/Mock/CreateSubscriptionSuccess.xml
@@ -82,7 +82,7 @@
           <index xmlns="" xsi:type="xsd:int">0</index>
           <product xmlns="" xsi:type="vin:Product">
             <VID xmlns="" xsi:type="xsd:string">fabcdef12340987651234098765fabcdef</VID>
-            <merchantProductId xmlns="" xsi:type="xsd:string">999999</merchantProductId>
+            <merchantProductId xmlns="" xsi:type="xsd:string">[ITEM_MERCHANT_PRODUCT_ID]</merchantProductId>
             <status xmlns="" xsi:type="vin:ProductStatus">Active</status>
             <taxClassification xmlns="" xsi:type="xsd:string">TaxExempt</taxClassification>
             <defaultBillingPlan xmlns="" xsi:type="vin:BillingPlan">


### PR DESCRIPTION
Allows custom values for `merchantProductId` on the autobill item in the `CreateSubscriptionSuccess` mock response. Intended for use with actual Vimeo product ids, which will enable unit testing certain features that require valid autobill items to be created from a Vindicia response.