### PR TITLE
Fix bug that defaults tax classification on update

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -144,7 +144,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
-     * Initialize request with parameters
+     * Initialize request with parameters.
+     * For new products, the default TAX_CLASSIFICATION is Tax Exempt
      *
      * @param array<string, mixed> $parameters
      * @return static
@@ -154,7 +155,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         if (!array_key_exists('timeout', $parameters)) {
             $parameters['timeout'] = self::DEFAULT_TIMEOUT;
         }
-        if (!array_key_exists('taxClassification', $parameters)) {
+        if (!$this->isUpdate() && !array_key_exists('taxClassification', $parameters)) {
             $parameters['taxClassification'] = self::DEFAULT_TAX_CLASSIFICATION;
         }
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -145,7 +145,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     /**
      * Initialize request with parameters.
-     * For new products, the default TAX_CLASSIFICATION is Tax Exempt
+     * For new products, the default tax classification is Tax Exempt
      *
      * @param array<string, mixed> $parameters
      * @return static

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -420,6 +420,21 @@ class AbstractRequestTest extends SoapTestCase
         $this->assertSame($prices, $this->request->getPrices());
     }
 
+    public function testDefaultParameterOnCreate() : void
+    {
+      $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
+      $request->initialize();
+      $this->assertSame(AbstractRequest::DEFAULT_TAX_CLASSIFICATION, $request->getTaxClassification());
+    }
+
+    public function testDefaultParameterOnUpdate() : void
+    {
+      $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
+      $request->shouldReceive('isUpdate')->andReturn(true);
+      $request->initialize();
+      $this->assertNull($request->getTaxClassification());
+    }
+
     /**
      * @return void
      */

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -420,14 +420,20 @@ class AbstractRequestTest extends SoapTestCase
         $this->assertSame($prices, $this->request->getPrices());
     }
 
-    public function testDefaultParameterOnCreate() : void
+    /**
+     * @return void
+     */
+    public function testDefaultParameterOnCreate()
     {
       $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
       $request->initialize();
       $this->assertSame(AbstractRequest::DEFAULT_TAX_CLASSIFICATION, $request->getTaxClassification());
     }
 
-    public function testDefaultParameterOnUpdate() : void
+    /**
+     * @return void
+     */
+    public function testDefaultParameterOnUpdate()
     {
       $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
       $request->shouldReceive('isUpdate')->andReturn(true);

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -425,9 +425,9 @@ class AbstractRequestTest extends SoapTestCase
      */
     public function testDefaultParameterOnCreate()
     {
-      $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
-      $request->initialize();
-      $this->assertSame(AbstractRequest::DEFAULT_TAX_CLASSIFICATION, $request->getTaxClassification());
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
+        $request->initialize();
+        $this->assertSame(AbstractRequest::DEFAULT_TAX_CLASSIFICATION, $request->getTaxClassification());
     }
 
     /**
@@ -435,10 +435,10 @@ class AbstractRequestTest extends SoapTestCase
      */
     public function testDefaultParameterOnUpdate()
     {
-      $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
-      $request->shouldReceive('isUpdate')->andReturn(true);
-      $request->initialize();
-      $this->assertNull($request->getTaxClassification());
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();
+        $request->shouldReceive('isUpdate')->andReturn(true);
+        $request->initialize();
+        $this->assertNull($request->getTaxClassification());
     }
 
     /**


### PR DESCRIPTION
Fixes a bug that would set a default tax classification as TAX_EXEMPT on update.  The default should only be set when creating new products, not on updates. 