### PR TITLE
Allow disabling purchase AVS/CVN policy on purchase

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -66,7 +66,11 @@ class PurchaseRequest extends AuthorizeRequest
         return 'authCapture';
     }
 
-    public function getData(string $paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    /**
+     * @param string $paymentMethodType
+     * @return array
+     */
+    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
         $data = parent::getData($paymentMethodType);
 
@@ -86,7 +90,10 @@ class PurchaseRequest extends AuthorizeRequest
         return $this->getParameter('ignoreAvsPolicy');
     }
 
-    public function setIgnoreAvsPolicy(bool $ignore)
+    /**
+     * @param bool $ignore
+     */
+    public function setIgnoreAvsPolicy($ignore)
     {
         $this->setParameter('ignoreAvsPolicy', $ignore);
     }
@@ -99,7 +106,10 @@ class PurchaseRequest extends AuthorizeRequest
         return $this->getParameter('ignoreCvnPolicy');
     }
 
-    public function setIgnoreCvnPolicy(bool $ignore)
+    /**
+     * @param bool $ignore
+     */
+    public function setIgnoreCvnPolicy($ignore)
     {
         $this->setParameter('ignoreCvnPolicy', $ignore);
     }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -92,6 +92,7 @@ class PurchaseRequest extends AuthorizeRequest
 
     /**
      * @param bool $ignore
+     * @return static
      */
     public function setIgnoreAvsPolicy($ignore)
     {
@@ -108,6 +109,7 @@ class PurchaseRequest extends AuthorizeRequest
 
     /**
      * @param bool $ignore
+     * @return static
      */
     public function setIgnoreCvnPolicy($ignore)
     {

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -62,13 +62,39 @@ class PurchaseRequest extends AuthorizeRequest
         return 'authCapture';
     }
 
-    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    public function getData(string $paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
         $data = parent::getData($paymentMethodType);
 
-        $data['ignoreAvsPolicy'] = false;
-        $data['ignoreCvnPolicy'] = false;
+        $data['ignoreAvsPolicy'] = $this->getIgnoreAvsPolicy();
+        $data['ignoreCvnPolicy'] = $this->getIgnoreCvnPolicy();
 
         return $data;
+    }
+
+    /**
+     * @return null|bool
+     */
+    public function getIgnoreAvsPolicy()
+    {
+        return $this->getParameter('ignoreAvsPolicy');
+    }
+
+    public function setIgnoreAvsPolicy(bool $ignore)
+    {
+        $this->setParameter('ignoreAvsPolicy', $ignore);
+    }
+
+    /**
+     * @return null|bool
+     */
+    public function getIgnoreCvnPolicy()
+    {
+        return $this->getParameter('ignoreCvnPolicy');
+    }
+
+    public function setIgnoreCvnPolicy(bool $ignore)
+    {
+        $this->setParameter('ignoreCvnPolicy', $ignore);
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -96,7 +96,7 @@ class PurchaseRequest extends AuthorizeRequest
      */
     public function setIgnoreAvsPolicy($ignore)
     {
-        $this->setParameter('ignoreAvsPolicy', $ignore);
+        return $this->setParameter('ignoreAvsPolicy', $ignore);
     }
 
     /**
@@ -113,6 +113,6 @@ class PurchaseRequest extends AuthorizeRequest
      */
     public function setIgnoreCvnPolicy($ignore)
     {
-        $this->setParameter('ignoreCvnPolicy', $ignore);
+        return $this->setParameter('ignoreCvnPolicy', $ignore);
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -6,7 +6,11 @@ namespace Omnipay\Vindicia\Message;
  * Purchase something! Money will be transferred. Calling purchase is the equivalent of
  * calling authorize and then calling capture.
  *
- * Takes the same parameters as authorize. See Message\AuthorizeRequest.
+ * Takes the same parameters as authorize, plus those listed below. See Message\AuthorizeRequest.
+ *
+ * Parameters:
+ * - ignoreAvsPolicy: Determines whether to check AVS validation on payment method. Default value is false.
+ * - ignoreCvnPolicy: Determines whether to check CVN validation on payment method. Default value is false.
  *
  * Example:
  * <code>

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -66,8 +66,10 @@ class PurchaseRequest extends AuthorizeRequest
     {
         $data = parent::getData($paymentMethodType);
 
-        $data['ignoreAvsPolicy'] = $this->getIgnoreAvsPolicy();
-        $data['ignoreCvnPolicy'] = $this->getIgnoreCvnPolicy();
+        $ignore_avs = $this->getIgnoreAvsPolicy();
+        $ignore_cvn = $this->getIgnoreCvnPolicy();
+        $data['ignoreAvsPolicy'] = $ignore_avs ? $ignore_avs : false;
+        $data['ignoreCvnPolicy'] = $ignore_cvn ? $ignore_cvn : false;
 
         return $data;
     }


### PR DESCRIPTION
Adds ability to set whether to ignore AVS/CVN policies in `PurchaseRequest`. 