### PR TITLE
Update vindicia staging api endpoints

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -10,7 +10,7 @@ namespace Omnipay\Vindicia;
  * your PCI compliance burden.
  *
  * Note that if you are using test mode, you will need a different username and password.
- * Test mode uses the https://soap.prodtest.sj.vindicia.com endpoint automatically.
+ * Test mode uses the https://soap.staging.us-west.vindicia.com endpoint automatically.
  *
  * Example:
  * <code>

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -44,7 +44,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     const API_VERSION = '18.0';
     const LIVE_ENDPOINT = 'https://soap.vindicia.com';
-    const TEST_ENDPOINT = 'https://soap.prodtest.sj.vindicia.com';
+    const TEST_ENDPOINT = 'https://soap.staging.us-west.vindicia.com';
+
     const VINDICIA_EXPIRATION_DATE_FORMAT = 'Ym';
 
     /**

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -465,7 +465,7 @@ class AbstractRequestTest extends SoapTestCase
             )
         );
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/' . $object . '.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/' . $object . '.wsdl', $this->getLastEndpoint());
         $this->assertSame(
             array(
                 'style'              => SOAP_DOCUMENT,

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -452,7 +452,7 @@ class AuthorizeRequestTest extends SoapTestCase
         $this->assertSame($this->transactionReference, $response->getTransactionReference());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -482,7 +482,7 @@ class AuthorizeRequestTest extends SoapTestCase
         $this->assertSame($this->transactionReference, $response->getTransactionReference());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CalculateSalesTaxRequestTest.php
+++ b/tests/Message/CalculateSalesTaxRequestTest.php
@@ -213,7 +213,7 @@ class CalculateSalesTaxRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->tax_amount, $response->getSalesTax());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CancelSubscriptionRequestTest.php
+++ b/tests/Message/CancelSubscriptionRequestTest.php
@@ -151,7 +151,7 @@ class CancelSubscriptionRequestTest extends SoapTestCase
         $this->assertSame('Pending Cancel', $response->getSubscriptionStatus());
         $this->assertSame($this->cancelReason, $response->getSubscriptionCancelReason());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CancelSubscriptionsRequestTest.php
+++ b/tests/Message/CancelSubscriptionsRequestTest.php
@@ -193,7 +193,7 @@ class CancelSubscriptionsRequestTest extends SoapTestCase
         $this->assertSame($this->customerId, $response->getCustomerId());
         $this->assertSame($this->customerReference, $response->getCustomerReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -67,7 +67,7 @@ class CaptureRequestTest extends SoapTestCase
         $this->assertSame('Ok', $response->getMessage());
         $this->assertSame($this->transactionId, $response->getTransactionId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CompleteCreatePayPalSubscriptionRequestTest.php
+++ b/tests/Message/CompleteCreatePayPalSubscriptionRequestTest.php
@@ -133,7 +133,7 @@ class CompleteCreatePayPalSubscriptionRequestTest extends SoapTestCase
         $this->assertSame($this->subscriptionId, $response->getSubscriptionId());
         $this->assertSame($this->subscriptionReference, $response->getSubscriptionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CompletePayPalPurchaseRequestTest.php
+++ b/tests/Message/CompletePayPalPurchaseRequestTest.php
@@ -125,7 +125,7 @@ class CompletePayPalPurchaseRequestTest extends SoapTestCase
         $this->assertSame($this->transactionId, $response->getTransactionId());
         $this->assertSame($this->transactionReference, $response->getTransactionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -276,7 +276,7 @@ class CreateCustomerRequestTest extends SoapTestCase
         $this->assertSame($this->customerId, $response->getCustomerId());
         $this->assertSame($this->customerReference, $response->getCustomerReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -310,7 +310,7 @@ class CreateCustomerRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
         $this->assertSame($this->paymentMethodReference, $response->getPaymentMethodReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreatePayPalSubscriptionRequestTest.php
+++ b/tests/Message/CreatePayPalSubscriptionRequestTest.php
@@ -418,7 +418,7 @@ class CreatePayPalSubscriptionRequestTest extends SoapTestCase
         $this->assertSame('https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&token=' . $this->payPalToken, $response->getRedirectUrl());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/CreatePaymentMethodRequestTest.php
@@ -434,7 +434,7 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
         $this->assertSame($this->paymentMethodReference, $response->getPaymentMethodReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -462,7 +462,7 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
         $this->assertSame($this->paymentMethodReference, $response->getPaymentMethodReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -492,7 +492,7 @@ class CreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
         $this->assertSame($this->paymentMethodReference, $response->getPaymentMethodReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreatePlanRequestTest.php
+++ b/tests/Message/CreatePlanRequestTest.php
@@ -333,7 +333,7 @@ class CreatePlanRequestTest extends SoapTestCase
         $this->assertSame($this->planId, $response->getPlanId());
         $this->assertSame($this->planReference, $response->getPlanReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreateProductRequestTest.php
+++ b/tests/Message/CreateProductRequestTest.php
@@ -324,7 +324,7 @@ class CreateProductRequestTest extends SoapTestCase
         $this->assertSame($this->productId, $response->getProductId());
         $this->assertSame($this->productReference, $response->getProductReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Product.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Product.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -541,7 +541,7 @@ class CreateSubscriptionRequestTest extends SoapTestCase
         $this->assertSame($this->riskScore, $response->getRiskScore());
         $this->assertSame($this->billingDay, $response->getBillingDay());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchChargebacksRequestTest.php
+++ b/tests/Message/FetchChargebacksRequestTest.php
@@ -217,7 +217,7 @@ class FetchChargebacksRequestTest extends SoapTestCase
         $this->assertSame($this->caseNumber, $chargeback->getCaseNumber());
         $this->assertSame($this->reasonCode, $chargeback->getReasonCode());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Chargeback.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Chargeback.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -241,7 +241,7 @@ class FetchChargebacksRequestTest extends SoapTestCase
         $this->assertNotNull($chargebacks[0]->getTransactionId());
         $this->assertNotNull($chargebacks[1]->getTransactionId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Chargeback.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Chargeback.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchCustomerRequestTest.php
+++ b/tests/Message/FetchCustomerRequestTest.php
@@ -120,7 +120,7 @@ class FetchCustomerRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -143,7 +143,7 @@ class FetchCustomerRequestTest extends SoapTestCase
         $this->assertSame($this->customerId, $response->getCustomerId());
         $this->assertSame($this->customerReference, $response->getCustomerReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Account.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Account.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchPaymentMethodRequestTest.php
+++ b/tests/Message/FetchPaymentMethodRequestTest.php
@@ -137,7 +137,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -160,7 +160,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
         $this->assertSame($this->paymentMethodReference, $response->getPaymentMethodReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -236,7 +236,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -261,7 +261,7 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isPending());
         $this->assertSame('OK', $response->getMessage());
-        
+
         $paymentMethod = $response->getPaymentMethod();
         $this->assertInstanceOf('\Omnipay\Vindicia\PaymentMethod', $paymentMethod);
         $this->assertSame($this->paymentMethodId, $response->getPaymentMethodId());
@@ -274,6 +274,6 @@ class FetchPaymentMethodRequestTest extends SoapTestCase
         $this->assertSame($this->card['country'], $card->getCountry());
         $this->assertSame($this->card['postcode'], $card->getPostcode());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 }

--- a/tests/Message/FetchPaymentMethodsRequestTest.php
+++ b/tests/Message/FetchPaymentMethodsRequestTest.php
@@ -94,7 +94,7 @@ class FetchPaymentMethodsRequestTest extends SoapTestCase
         $this->assertNotNull($paymentMethods[0]->getId());
         $this->assertNotNull($paymentMethods[1]->getId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/PaymentMethod.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchPlanRequestTest.php
+++ b/tests/Message/FetchPlanRequestTest.php
@@ -123,7 +123,7 @@ class FetchPlanRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -146,7 +146,7 @@ class FetchPlanRequestTest extends SoapTestCase
         $this->assertSame($this->planId, $response->getPlanId());
         $this->assertSame($this->planReference, $response->getPlanReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/BillingPlan.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchProductRequestTest.php
+++ b/tests/Message/FetchProductRequestTest.php
@@ -136,7 +136,7 @@ class FetchProductRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Product.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Product.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -159,7 +159,7 @@ class FetchProductRequestTest extends SoapTestCase
         $this->assertSame($this->productId, $response->getProductId());
         $this->assertSame($this->productReference, $response->getProductReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Product.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Product.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchRefundsRequestTest.php
+++ b/tests/Message/FetchRefundsRequestTest.php
@@ -183,7 +183,7 @@ class FetchRefundsRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Refund.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Refund.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -206,7 +206,7 @@ class FetchRefundsRequestTest extends SoapTestCase
         $this->assertSame(1, count($refunds));
         $this->assertNotNull($refunds[0]->getId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Refund.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Refund.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchSubscriptionInvoiceReferencesRequestTest.php
+++ b/tests/Message/FetchSubscriptionInvoiceReferencesRequestTest.php
@@ -111,7 +111,7 @@ class FetchSubscriptionInvoiceReferencesRequestTest extends SoapTestCase
         $this->assertEquals(2, count($invoice_references_array));
         $this->assertSame($this->invoiceReference, $invoice_references_array[0]);
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchSubscriptionInvoiceRequestTest.php
+++ b/tests/Message/FetchSubscriptionInvoiceRequestTest.php
@@ -122,7 +122,7 @@ class FetchSubscriptionInvoiceRequestTest extends SoapTestCase
         }
         $this->assertEquals($this->amount, $amount);
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchSubscriptionRequestTest.php
+++ b/tests/Message/FetchSubscriptionRequestTest.php
@@ -177,7 +177,7 @@ class FetchSubscriptionRequestTest extends SoapTestCase
             $this->assertInstanceOf('\Omnipay\Vindicia\Attribute', $attribute);
         }
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -200,7 +200,7 @@ class FetchSubscriptionRequestTest extends SoapTestCase
         $this->assertSame($this->subscriptionId, $response->getSubscriptionId());
         $this->assertSame($this->subscriptionReference, $response->getSubscriptionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchSubscriptionsRequestTest.php
+++ b/tests/Message/FetchSubscriptionsRequestTest.php
@@ -192,7 +192,7 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
         $this->assertNotNull($subscriptions[0]->getId());
         $this->assertNotNull($subscriptions[1]->getId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -214,7 +214,7 @@ class FetchSubscriptionsRequestTest extends SoapTestCase
         $this->assertNotNull($subscriptions[0]->getId());
         $this->assertNotNull($subscriptions[1]->getId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/FetchTransactionRequestTest.php
+++ b/tests/Message/FetchTransactionRequestTest.php
@@ -216,7 +216,7 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->assertEquals($this->shippingAddress1, $card->getShippingAddress1());
         $this->assertEquals($this->shippingCity, $card->getShippingCity());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -241,7 +241,7 @@ class FetchTransactionRequestTest extends SoapTestCase
         $this->assertSame($this->transactionId, $response->getTransaction()->getId());
         $this->assertEquals($this->timestamp, $response->getTransaction()->getTimestamp());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -366,6 +366,6 @@ class FetchTransactionRequestTest extends SoapTestCase
         }
         $this->assertEquals($this->timestamp, $transaction->getTimestamp());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 }

--- a/tests/Message/FetchTransactionsRequestTest.php
+++ b/tests/Message/FetchTransactionsRequestTest.php
@@ -191,7 +191,7 @@ class FetchTransactionsRequestTest extends SoapTestCase
         $this->assertEquals($this->timestamp, $transactions[0]->getTimestamp());
         $this->assertEquals($this->timestamp, $transactions[1]->getTimestamp());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -217,7 +217,7 @@ class FetchTransactionsRequestTest extends SoapTestCase
         $this->assertEquals($this->timestamp, $transactions[0]->getTimestamp());
         $this->assertEquals($this->timestamp, $transactions[1]->getTimestamp());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/HOAAuthorizeRequestTest.php
+++ b/tests/Message/HOAAuthorizeRequestTest.php
@@ -460,7 +460,7 @@ class HOAAuthorizeRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->webSessionReference, $response->getWebSessionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/WebSession.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/WebSession.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/HOACreatePaymentMethodRequestTest.php
+++ b/tests/Message/HOACreatePaymentMethodRequestTest.php
@@ -282,7 +282,7 @@ class HOACreatePaymentMethodRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->webSessionReference, $response->getWebSessionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/WebSession.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/WebSession.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/HOACreateSubscriptionRequestTest.php
+++ b/tests/Message/HOACreateSubscriptionRequestTest.php
@@ -445,7 +445,7 @@ class HOACreateSubscriptionRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->webSessionReference, $response->getWebSessionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/WebSession.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/WebSession.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/HOAPurchaseRequestTest.php
+++ b/tests/Message/HOAPurchaseRequestTest.php
@@ -461,7 +461,7 @@ class HOAPurchaseRequestTest extends SoapTestCase
         $this->assertSame('OK', $response->getMessage());
         $this->assertSame($this->webSessionReference, $response->getWebSessionReference());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/WebSession.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/WebSession.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/MakePaymentRequestTest.php
+++ b/tests/Message/MakePaymentRequestTest.php
@@ -165,7 +165,7 @@ class MakePaymentRequestTest extends SoapTestCase
 
         $this->assertSame($this->summary, $response->getSummary());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/AutoBill.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/AutoBill.wsdl', $this->getLastEndpoint());
     }
 
         /**

--- a/tests/Message/PayPalPurchaseRequestTest.php
+++ b/tests/Message/PayPalPurchaseRequestTest.php
@@ -419,7 +419,7 @@ class PayPalPurchaseRequestTest extends SoapTestCase
         $this->assertSame('https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=' . $this->payPalToken, $response->getRedirectUrl());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -455,7 +455,7 @@ class PurchaseRequestTest extends SoapTestCase
         $this->assertSame($this->soapId, $response->getSoapId());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**
@@ -487,7 +487,7 @@ class PurchaseRequestTest extends SoapTestCase
         $this->assertSame($this->soapId, $response->getSoapId());
         $this->assertSame($this->riskScore, $response->getRiskScore());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -364,7 +364,7 @@ class RefundRequestTest extends SoapTestCase
         $this->assertSame($this->refundAmount, $refund->getAmount());
         $this->assertSame($this->reason, $refund->getReason());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Refund.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Refund.wsdl', $this->getLastEndpoint());
     }
 
     /**

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -67,7 +67,7 @@ class VoidRequestTest extends SoapTestCase
         $this->assertSame('Ok', $response->getMessage());
         $this->assertSame($this->transactionId, $response->getTransactionId());
 
-        $this->assertSame('https://soap.prodtest.sj.vindicia.com/18.0/Transaction.wsdl', $this->getLastEndpoint());
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
     }
 
     /**


### PR DESCRIPTION
* Updates the old Vindicia staging endpoint (`'https://soap.prodtest.sj.vindicia.com`) to the new endpoint on AWS `https://soap.staging.us-west.vindicia.com` based on this migration doc https://knowledge.vindicia.com/Frequently_Asked_Questions/Cloud_Move_Resources/IP_Address_and_Staging_URL_Changes
* Replace all literal strings for this endpoint with the `AbstractRequest::TEST_ENDPOINT` const 