### PR TITLE
Add status to Refund object

### DIFF
--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -327,7 +327,8 @@ class ObjectHelper
             'transactionId' => isset($transaction) ? $transaction->getTransactionId() : null,
             'transactionReference' => isset($transaction) ? $transaction->getTransactionReference() : null,
             'items' => isset($items) ? $items : null,
-            'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null
+            'attributes' => isset($object->nameValues) ? $this->buildAttributes($object->nameValues) : null,
+            'status' => isset($object->status) ? $object->status : null,
         ));
     }
 

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -347,6 +347,27 @@ class Refund
     }
 
     /**
+     * Get the status
+     *
+     * @return null|string
+     */
+    public function getStatus()
+    {
+        return $this->getParameter('status');
+    }
+
+    /**
+     * Set the status
+     *
+     * @param string $value
+     * @return static
+     */
+    public function setStatus($value)
+    {
+        return $this->setParameter('status', $value);
+    }
+
+    /**
      * A list of attributes
      *
      * @return AttributeBag|null


### PR DESCRIPTION
According to [Vindicia documentation](https://www.vindicia.com/documents/1800APIGuideHTML5/Default.htm#APIGuide/Refund_Data_Members.htm%3FTocPath%3DCashBox1800APIGuide%7C15%2520The%2520Refund%2520Object%7C_____1) Refund objects have a status field which can be any of the following: Reported, Processing, Failed, Complete.