### PR TITLE
Set product qty

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -418,6 +418,22 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     * @return int
+     */
+    public function getQuantity()
+    {
+        return $this->getParameter('quantity');
+    }
+
+    /**
+     * @return static
+     */
+    public function setQuantity($value)
+    {
+        return $this->setParameter('quantity', $value);
+    }
+
+    /**
      * @return static
      */
     public function setProductId($value)

--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -278,6 +278,7 @@ class CreateSubscriptionRequest extends AuthorizeRequest
             $item = new stdClass();
             $item->index = 0; //set the item index
             $item->product = $product;
+            $item->quantity = $this->getQuantity();
             $subscription->items = array($item);
         }
 

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -433,6 +433,16 @@ class AbstractRequestTest extends SoapTestCase
     /**
      * @return void
      */
+    public function testQuantity()
+    {
+        $quantity = mt_rand(1);
+        $this->assertSame($this->request, $this->request->setQuantity($quantity));
+        $this->assertSame($quantity, $this->request->getQuantity());
+    }
+
+    /**
+     * @return void
+     */
     public function testDefaultParameterOnUpdate()
     {
         $request = Mocker::mock('\Omnipay\Vindicia\Message\AbstractRequest')->makePartial()->shouldAllowMockingProtectedMethods();

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -435,7 +435,7 @@ class AbstractRequestTest extends SoapTestCase
      */
     public function testQuantity()
     {
-        $quantity = mt_rand(1);
+        $quantity = mt_rand(1, mt_getrandmax());
         $this->assertSame($this->request, $this->request->setQuantity($quantity));
         $this->assertSame($quantity, $this->request->getQuantity());
     }


### PR DESCRIPTION
We never actually made use of the subscription qty when creating a subscription on Vindicia. This PR makes sure that the quantity is set