### PR TITLE
Assign autoBillItemVid values to transaction items

### DIFF
--- a/src/ObjectHelper.php
+++ b/src/ObjectHelper.php
@@ -35,7 +35,8 @@ class ObjectHelper
                     'sku' => isset($item->sku) ? $item->sku : null,
                     'quantity' => isset($item->quantity) ? $item->quantity : null,
                     'name' => isset($item->name) ? $item->name : null,
-                    'taxClassification' => isset($item->taxClassification) ? $item->taxClassification : null
+                    'taxClassification' => isset($item->taxClassification) ? $item->taxClassification : null,
+                    'autoBillItemVid' => isset($item->autoBillItemVid) ? $item->autoBillItemVid : null
                 ));
             }
         }
@@ -306,7 +307,7 @@ class ObjectHelper
             $items = array();
             foreach ($object->refundItems as $item) {
                 $items[] = new VindiciaRefundItem(array(
-                    'amount' => isset($item->amount) ? $item->amount: null,
+                    'amount' => isset($item->amount) ? $item->amount : null,
                     'sku' => isset($item->sku) ? $item->sku : null,
                     'transactionItemIndexNumber' => isset($item->transactionItemIndexNumber)
                                                   ? $item->transactionItemIndexNumber

--- a/src/TestFramework/DataFaker.php
+++ b/src/TestFramework/DataFaker.php
@@ -101,7 +101,7 @@ class DataFaker
      *
      * @return string
      */
-    public function autobillItemVid()
+    public function autoBillItemVid()
     {
         do {
             $result = $this->randomCharacters(self::HEX_CHARACTERS, 40);
@@ -630,7 +630,7 @@ class DataFaker
             'price' => $this->monetaryAmount($currency),
             'sku' => $this->sku(),
             'taxClassification' => $this->taxClassification(),
-            'autoBillItemVid' => $this->autobillItemVid()
+            'autoBillItemVid' => $this->autoBillItemVid()
         );
     }
 

--- a/tests/Mock/FetchTransactionByReferenceSuccess.xml
+++ b/tests/Mock/FetchTransactionByReferenceSuccess.xml
@@ -103,6 +103,7 @@
           <taxType xmlns="" xsi:type="xsd:string">Exclusive Sales</taxType>
           <subtotal xmlns="" xsi:type="xsd:decimal">200</subtotal>
           <total xmlns="" xsi:type="xsd:decimal">200</total>
+          <autoBillItemVid xmlns="" xsi:type="xsd:string">[AUTOBILL_ITEM_VID]</autoBillItemVid>
         </transactionItems>
         <transactionItems xmlns="" xsi:type="vin:TransactionItem">
           <sku xmlns="" xsi:type="xsd:string">Total Tax</sku>

--- a/tests/VindiciaItemTest.php
+++ b/tests/VindiciaItemTest.php
@@ -120,9 +120,9 @@ class VindiciaItemTest extends TestCase
     public function testAutoBillItemVid()
     {
         $item = new VindiciaItem();
-        $autobillItemVid = $this->faker->autobillItemVid();
-        $this->assertSame($item, $item->setAutoBillItemVid($autobillItemVid));
-        $this->assertSame($autobillItemVid, $item->getAutoBillItemVid());
+        $autoBillItemVid = $this->faker->autoBillItemVid();
+        $this->assertSame($item, $item->setAutoBillItemVid($autoBillItemVid));
+        $this->assertSame($autoBillItemVid, $item->getAutoBillItemVid());
     }
 
     /**


### PR DESCRIPTION
Updates the` ObjectHelper->buildTransaction()` method to assign `autoBillItemVid` values.