### PR TITLE
Add PayPalGateway::authorize

### DIFF
--- a/src/Message/PayPalAuthRequest.php
+++ b/src/Message/PayPalAuthRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+class PayPalPurchaseRequest extends AuthorizeRequest
+{
+    /**
+     * The class to use for the response.
+     *
+     * @var string
+     */
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\PayPalPurchaseResponse';
+
+    public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
+    {
+        $this->validate('returnUrl', 'cancelUrl');
+
+        return parent::getData(self::PAYMENT_METHOD_PAYPAL);
+    }
+
+    /**
+     * Overriding to provide a more precise return type
+     * @return PayPalPurchaseResponse
+     */
+    public function send()
+    {
+        /**
+         * @var PayPalPurchaseResponse
+         */
+        return parent::send();
+    }
+}

--- a/src/Message/PayPalAuthRequest.php
+++ b/src/Message/PayPalAuthRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Vindicia\Message;
 
-class PayPalPurchaseRequest extends AuthorizeRequest
+class PayPalAuthRequest extends AuthorizeRequest
 {
     /**
      * The class to use for the response.

--- a/src/Message/PayPalAuthorizeRequest.php
+++ b/src/Message/PayPalAuthorizeRequest.php
@@ -9,7 +9,7 @@ class PayPalAuthorizeRequest extends AuthorizeRequest
      *
      * @var string
      */
-    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\PayPalPurchaseResponse';
+    protected static $RESPONSE_CLASS = '\Omnipay\Vindicia\Message\PayPalAuthorizeResponse';
 
     public function getData($paymentMethodType = self::PAYMENT_METHOD_CREDIT_CARD)
     {
@@ -20,12 +20,12 @@ class PayPalAuthorizeRequest extends AuthorizeRequest
 
     /**
      * Overriding to provide a more precise return type
-     * @return PayPalPurchaseResponse
+     * @return PayPalAuthorizeResponse
      */
     public function send()
     {
         /**
-         * @var PayPalPurchaseResponse
+         * @var PayPalAuthorizeResponse
          */
         return parent::send();
     }

--- a/src/Message/PayPalAuthorizeRequest.php
+++ b/src/Message/PayPalAuthorizeRequest.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Vindicia\Message;
 
-class PayPalAuthRequest extends AuthorizeRequest
+class PayPalAuthorizeRequest extends AuthorizeRequest
 {
     /**
      * The class to use for the response.

--- a/src/Message/PayPalAuthorizeResponse.php
+++ b/src/Message/PayPalAuthorizeResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+class PayPalAuthorizeResponse extends Response
+{
+    /**
+     * Is the response successful?
+     * Throws an exception if there's no code.
+     *
+     * @return boolean
+     * @throws \Omnipay\Common\Exception\InvalidResponseException
+     */
+    public function isSuccessful()
+    {
+        return parent::isSuccessful() && $this->getRedirectUrl();
+    }
+
+    /**
+     * Is the response a redirect?
+     * Throws an exception if there's no code.
+     * Successful PayPal authorize responses are always redirects.
+     *
+     * @return boolean
+     * @throws \Omnipay\Common\Exception\InvalidResponseException
+     */
+    public function isRedirect()
+    {
+        return $this->isSuccessful();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRedirectUrl()
+    {
+        $transaction = $this->getTransaction();
+        if (isset($transaction)) {
+            return $transaction->getPayPalRedirectUrl();
+        }
+        return null;
+    }
+}

--- a/src/PayPalGateway.php
+++ b/src/PayPalGateway.php
@@ -77,14 +77,14 @@ class PayPalGateway extends AbstractVindiciaGateway
     /**
      * Authorize a transaction. No money will actually be transferred.
      * 
-     * @return PayPalAuthRequest
+     * @return PayPalAuthorizeRequest
      */
     public function authorize($parameters = array())
     {
         /**
-         * @var \Omnipay\Vindicia\Message\PayPalAuthRequest
+         * @var \Omnipay\Vindicia\Message\PayPalAuthorizeRequest
          */
-        return $this->createRequest('\Omnipay\Vindicia\Message\PayPalAuthRequest', $parameters);
+        return $this->createRequest('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest', $parameters);
     }
 
     /**

--- a/src/PayPalGateway.php
+++ b/src/PayPalGateway.php
@@ -75,6 +75,19 @@ class PayPalGateway extends AbstractVindiciaGateway
     }
 
     /**
+     * Authorize a transaction. No money will actually be transferred.
+     * 
+     * @return PayPalAuthRequest
+     */
+    public function authorize($parameters = array())
+    {
+        /**
+         * @var \Omnipay\Vindicia\Message\PayPalAuthRequest
+         */
+        return $this->createRequest('\Omnipay\Vindicia\Message\PayPalAuthRequest', $parameters);
+    }
+
+    /**
      * Begin a PayPal purchase. A redirect URL will be returned to send the user to PayPal's
      * website.
      *

--- a/tests/Message/PayPalAuthorizeRequestTest.php
+++ b/tests/Message/PayPalAuthorizeRequestTest.php
@@ -5,7 +5,6 @@ namespace Omnipay\Vindicia\Message;
 use Omnipay\Common\CreditCard;
 use Omnipay\Vindicia\AttributeBag;
 use Omnipay\Vindicia\Message\PayPalAuthorizeRequest;
-use Omnipay\Vindicia\Message\PayPalPurchaseRequest;
 use Omnipay\Vindicia\NameValue;
 use Omnipay\Vindicia\TestFramework\DataFaker;
 use Omnipay\Vindicia\TestFramework\Mocker;

--- a/tests/Message/PayPalAuthorizeRequestTest.php
+++ b/tests/Message/PayPalAuthorizeRequestTest.php
@@ -394,7 +394,7 @@ class PayPalAuthorizeRequestTest extends SoapTestCase
      */
     public function testSendSuccess()
     {
-        $this->setMockSoapResponse('PayPalPurchaseSuccess.xml', array(
+        $this->setMockSoapResponse('PayPalAuthorizeSuccess.xml', array(
             'CURRENCY' => $this->currency,
             'AMOUNT' => $this->amount,
             'CUSTOMER_ID' => $this->customerId,
@@ -428,7 +428,7 @@ class PayPalAuthorizeRequestTest extends SoapTestCase
      */
     public function testSendFailure()
     {
-        $this->setMockSoapResponse('PayPalPurchaseFailure.xml');
+        $this->setMockSoapResponse('PayPalAuthorizeFailure.xml');
 
         $response = $this->request->send();
 
@@ -436,7 +436,7 @@ class PayPalAuthorizeRequestTest extends SoapTestCase
         $this->assertFalse($response->isRedirect());
         $this->assertFalse($response->isPending());
         $this->assertSame('400', $response->getCode());
-        $this->assertSame('Must specify line items in transaction to calculate sales tax for auth!', $response->getMessage());
+        $this->assertSame('Authorization failed.', $response->getMessage());
 
         $this->assertNull($response->getTransactionId());
         $this->assertNull($response->getTransactionReference());

--- a/tests/Message/PayPalAuthorizeRequestTest.php
+++ b/tests/Message/PayPalAuthorizeRequestTest.php
@@ -1,0 +1,446 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+use Omnipay\Common\CreditCard;
+use Omnipay\Vindicia\AttributeBag;
+use Omnipay\Vindicia\Message\PayPalAuthorizeRequest;
+use Omnipay\Vindicia\Message\PayPalPurchaseRequest;
+use Omnipay\Vindicia\NameValue;
+use Omnipay\Vindicia\TestFramework\DataFaker;
+use Omnipay\Vindicia\TestFramework\Mocker;
+use Omnipay\Vindicia\TestFramework\SoapTestCase;
+use Omnipay\Vindicia\VindiciaItemBag;
+
+class PayPalAuthorizeRequestTest extends SoapTestCase
+{
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->faker = new DataFaker();
+
+        $this->currency = $this->faker->currency();
+        $this->amount = $this->faker->monetaryAmount($this->currency);
+        $this->customerId = $this->faker->customerId();
+        $this->customerReference = $this->faker->customerReference();
+        $this->paymentMethodId = $this->faker->paymentMethodId();
+        $this->statementDescriptor = $this->faker->statementDescriptor();
+        $this->ip = $this->faker->ipAddress();
+        $this->attributes = $this->faker->attributesAsArray();
+        $this->taxClassification = $this->faker->taxClassification();
+        $this->returnUrl = $this->faker->url();
+        $this->cancelUrl = $this->faker->url();
+        $this->card = array(
+            'country' => $this->faker->region(),
+            'postcode' => $this->faker->postcode()
+        );
+
+        $this->request = new PayPalAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'amount' => $this->amount,
+                'currency' => $this->currency,
+                'card' => $this->card,
+                'paymentMethodId' => $this->paymentMethodId,
+                'customerId' => $this->customerId,
+                'customerReference' => $this->customerReference,
+                'statementDescriptor' => $this->statementDescriptor,
+                'ip' => $this->ip,
+                'attributes' => $this->attributes,
+                'taxClassification' => $this->taxClassification,
+                'returnUrl' => $this->returnUrl,
+                'cancelUrl' => $this->cancelUrl
+            )
+        );
+
+        $this->transactionId = $this->faker->transactionId();
+        $this->transactionReference = $this->faker->transactionReference();
+        $this->items = $this->faker->itemsAsArray($this->currency);
+        $this->paymentMethodReference = $this->faker->paymentMethodReference();
+        $this->payPalToken = $this->faker->payPalToken();
+        $this->riskScore = $this->faker->riskScore();
+    }
+
+    /**
+     * @return void
+     */
+    public function testStatementDescriptor()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setStatementDescriptor($this->statementDescriptor));
+        $this->assertSame($this->statementDescriptor, $request->getStatementDescriptor());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIp()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setIp($this->ip));
+        $this->assertSame($this->ip, $request->getIp());
+    }
+
+    /**
+     * @return void
+     */
+    public function testItems()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setItems($this->items));
+        $this->assertEquals(new VindiciaItemBag($this->items), $request->getItems());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCustomerId()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCustomerId($this->customerId));
+        $this->assertSame($this->customerId, $request->getCustomerId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCustomerReference()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCustomerReference($this->customerReference));
+        $this->assertSame($this->customerReference, $request->getCustomerReference());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCard()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCard($this->card));
+        $this->assertEquals(new CreditCard($this->card), $request->getCard());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPaymentMethodId()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPaymentMethodId($this->paymentMethodId));
+        $this->assertSame($this->paymentMethodId, $request->getPaymentMethodId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPaymentMethodReference()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setPaymentMethodReference($this->paymentMethodReference));
+        $this->assertSame($this->paymentMethodReference, $request->getPaymentMethodReference());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCurrency()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCurrency($this->currency));
+        $this->assertSame($this->currency, $request->getCurrency());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAmount()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $request->setCurrency($this->currency);
+        $this->assertSame($request, $request->setAmount($this->amount));
+        $this->assertSame($this->amount, $request->getAmount());
+    }
+
+    /**
+     * @return void
+     */
+    public function testTransactionId()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setTransactionId($this->transactionId));
+        $this->assertSame($this->transactionId, $request->getTransactionId());
+    }
+
+    /**
+     * @return void
+     */
+    public function testTaxClassification()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setTaxClassification($this->taxClassification));
+        $this->assertSame($this->taxClassification, $request->getTaxClassification());
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnUrl()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setReturnUrl($this->returnUrl));
+        $this->assertEquals($this->returnUrl, $request->getReturnUrl());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCancelUrl()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setCancelUrl($this->cancelUrl));
+        $this->assertEquals($this->cancelUrl, $request->getCancelUrl());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAttributes()
+    {
+        $request = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeRequest')->makePartial();
+        $request->initialize();
+
+        $this->assertSame($request, $request->setAttributes($this->attributes));
+        $this->assertEquals(new AttributeBag($this->attributes), $request->getAttributes());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame($this->amount, $data['transaction']->transactionItems[0]->price);
+        $this->assertSame($this->taxClassification, $data['transaction']->transactionItems[0]->taxClassification);
+        $this->assertSame(1, $data['transaction']->transactionItems[0]->quantity);
+        $this->assertSame($this->currency, $data['transaction']->currency);
+        $this->assertSame($this->customerId, $data['transaction']->account->merchantAccountId);
+        $this->assertSame($this->customerReference, $data['transaction']->account->VID);
+        $this->assertSame($this->paymentMethodId, $data['transaction']->sourcePaymentMethod->merchantPaymentMethodId);
+        $this->assertSame($this->statementDescriptor, $data['transaction']->billingStatementIdentifier);
+        $this->assertSame($this->ip, $data['transaction']->sourceIp);
+        $this->assertSame($this->returnUrl, $data['transaction']->sourcePaymentMethod->paypal->returnUrl);
+        $this->assertSame($this->cancelUrl, $data['transaction']->sourcePaymentMethod->paypal->cancelUrl);
+        $this->assertSame('PayPal', $data['transaction']->sourcePaymentMethod->type);
+        $this->assertSame($this->card['postcode'], $data['transaction']->sourcePaymentMethod->billingAddress->postalCode);
+        $this->assertSame($this->card['country'], $data['transaction']->sourcePaymentMethod->billingAddress->country);
+
+        $numAttributes = count($this->attributes);
+        $this->assertSame($numAttributes, count($data['transaction']->nameValues));
+        for ($i = 0; $i < $numAttributes; $i++) {
+            $this->assertSame($this->attributes[$i]['name'], $data['transaction']->nameValues[$i]->name);
+            $this->assertSame($this->attributes[$i]['value'], $data['transaction']->nameValues[$i]->value);
+        }
+
+        $this->assertSame('auth', $data['action']);
+        $this->assertSame(false, $data['sendEmailNotification']);
+        $this->assertNull($data['campaignCode']);
+        $this->assertSame(false, $data['dryrun']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetDataMultipleItems()
+    {
+        $this->request->setAmount(null)->setItems($this->items);
+
+        $data = $this->request->getData();
+
+        $numItems = count($this->items);
+        $this->assertSame($numItems, count($data['transaction']->transactionItems));
+        for ($i = 0; $i < $numItems; $i++) {
+            $this->assertSame($this->items[$i]['price'], $data['transaction']->transactionItems[$i]->price);
+            $this->assertSame($this->items[$i]['quantity'], $data['transaction']->transactionItems[$i]->quantity);
+            $this->assertSame($this->items[$i]['sku'], $data['transaction']->transactionItems[$i]->sku);
+            $this->assertEquals(array(new NameValue('description', $this->items[$i]['description'])), $data['transaction']->transactionItems[$i]->nameValues);
+            $this->assertSame($this->items[$i]['taxClassification'], $data['transaction']->transactionItems[$i]->taxClassification);
+        }
+
+        $this->assertSame($this->currency, $data['transaction']->currency);
+        $this->assertSame($this->customerId, $data['transaction']->account->merchantAccountId);
+        $this->assertSame($this->customerReference, $data['transaction']->account->VID);
+        $this->assertSame($this->paymentMethodId, $data['transaction']->sourcePaymentMethod->merchantPaymentMethodId);
+        $this->assertSame($this->statementDescriptor, $data['transaction']->billingStatementIdentifier);
+        $this->assertSame($this->ip, $data['transaction']->sourceIp);
+        $this->assertSame($this->returnUrl, $data['transaction']->sourcePaymentMethod->paypal->returnUrl);
+        $this->assertSame($this->cancelUrl, $data['transaction']->sourcePaymentMethod->paypal->cancelUrl);
+        $this->assertSame('PayPal', $data['transaction']->sourcePaymentMethod->type);
+        $this->assertSame($this->card['postcode'], $data['transaction']->sourcePaymentMethod->billingAddress->postalCode);
+        $this->assertSame($this->card['country'], $data['transaction']->sourcePaymentMethod->billingAddress->country);
+
+        $numAttributes = count($this->attributes);
+        $this->assertSame($numAttributes, count($data['transaction']->nameValues));
+        for ($i = 0; $i < $numAttributes; $i++) {
+            $this->assertSame($this->attributes[$i]['name'], $data['transaction']->nameValues[$i]->name);
+            $this->assertSame($this->attributes[$i]['value'], $data['transaction']->nameValues[$i]->value);
+        }
+
+        $this->assertSame('auth', $data['action']);
+        $this->assertSame(false, $data['sendEmailNotification']);
+        $this->assertNull($data['campaignCode']);
+        $this->assertSame(false, $data['dryrun']);
+    }
+
+    /**
+     * @expectedException        \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage Either the amount or items parameter is required.
+     * @return                   void
+     */
+    public function testAmountRequired()
+    {
+        $this->request->setAmount(null);
+        $this->request->getData();
+    }
+
+    /**
+     * @expectedException        \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage The returnUrl parameter is required
+     * @return                   void
+     */
+    public function testReturnUrlRequired()
+    {
+        $this->request->setReturnUrl(null);
+        $this->request->getData();
+    }
+
+    /**
+     * @expectedException        \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage The cancelUrl parameter is required
+     * @return                   void
+     */
+    public function testCancelUrlRequired()
+    {
+        $this->request->setCancelUrl(null);
+        $this->request->getData();
+    }
+
+    /**
+     * @expectedException        \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage Sum of item prices not equal to set amount.
+     * @return                   void
+     */
+    public function testAmountMustEqualSumOfItems()
+    {
+        $items = new VindiciaItemBag($this->items);
+
+        $sumOfItems = '0.0';
+        foreach ($items as $item) {
+            $sumOfItems = strval($sumOfItems + $item->getPrice() * $item->getQuantity());
+        }
+
+        do {
+            $amount = $this->faker->monetaryAmount($this->currency);
+        } while ($amount == $sumOfItems);
+
+        $request = new PayPalAuthorizeRequest($this->getHttpClient(), $this->getHttpRequest());
+        $request->initialize(
+            array(
+                'currency' => $this->currency,
+                'paymentMethodId' => $this->paymentMethodId,
+                'customerId' => $this->customerId,
+                'items' => $items,
+                'amount' => $amount,
+                'returnUrl' => $this->returnUrl,
+                'cancelUrl' => $this->cancelUrl
+            )
+        );
+
+        $request->getData();
+    }
+
+    /**
+     * @return void
+     */
+    public function testSendSuccess()
+    {
+        $this->setMockSoapResponse('PayPalPurchaseSuccess.xml', array(
+            'CURRENCY' => $this->currency,
+            'AMOUNT' => $this->amount,
+            'CUSTOMER_ID' => $this->customerId,
+            'CUSTOMER_REFERENCE' => $this->customerReference,
+            'PAYMENT_METHOD_ID' => $this->paymentMethodId,
+            'PAYMENT_METHOD_REFERENCE' => $this->paymentMethodReference,
+            'TRANSACTION_ID' => $this->transactionId,
+            'TRANSACTION_REFERENCE' => $this->transactionReference,
+            'RETURN_URL' => $this->returnUrl,
+            'CANCEL_URL' => $this->cancelUrl,
+            'PAYPAL_TOKEN' => $this->payPalToken,
+            'RISK_SCORE' => $this->riskScore
+        ));
+
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertFalse($response->isPending());
+        $this->assertSame('OK', $response->getMessage());
+        $this->assertSame($this->transactionId, $response->getTransactionId());
+        $this->assertSame($this->transactionReference, $response->getTransactionReference());
+        $this->assertSame('https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=' . $this->payPalToken, $response->getRedirectUrl());
+        $this->assertSame($this->riskScore, $response->getRiskScore());
+
+        $this->assertSame(AbstractRequest::TEST_ENDPOINT . '/18.0/Transaction.wsdl', $this->getLastEndpoint());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSendFailure()
+    {
+        $this->setMockSoapResponse('PayPalPurchaseFailure.xml');
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertFalse($response->isPending());
+        $this->assertSame('400', $response->getCode());
+        $this->assertSame('Must specify line items in transaction to calculate sales tax for auth!', $response->getMessage());
+
+        $this->assertNull($response->getTransactionId());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getRedirectUrl());
+    }
+}

--- a/tests/Message/PayPalAuthorizeResponseTest.php
+++ b/tests/Message/PayPalAuthorizeResponseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Omnipay\Vindicia\Message;
+
+use Omnipay\Vindicia\TestFramework\Mocker;
+use Omnipay\Vindicia\TestFramework\SoapTestCase;
+
+class PayPalAuthorizeResponseTest extends SoapTestCase
+{
+    /**
+     * @dataProvider provideForTestIsSuccessful
+     */
+    public function testIsSuccessful(string $return_code, ?string $redirect_url, bool $expected_is_successful): void
+    {
+        $response = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeResponse', [
+            'getCode' => $return_code,
+            'getRedirectUrl' => $redirect_url,
+        ])->makePartial();
+        $this->assertSame($expected_is_successful, $response->isSuccessful());
+    }
+
+    public function provideForTestIsSuccessful(): array
+    {
+        return [
+            '200 return code with redirect url indicates success' => [
+                'return_code' => '200',
+                'redirect_url' => 'https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=1234',
+                'expected_is_successful' => true,
+            ],
+            'redirect url is required' => [
+                'return_code' => '200',
+                'redirect_url' => null,
+                'expected_is_successful' => false,
+            ],
+            '202 on an authorize means that the tax service was unavailable, but the request still succeeded' => [
+                'return_code' => '202',
+                'redirect_url' => 'https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=1234',
+                'expected_is_successful' => true,
+            ],
+            '400 return code indicates failure' => [
+                'return_code' => '400',
+                'redirect_url' => 'https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=1234',
+                'expected_is_successful' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForTestIsRedirect
+     */
+    public function testIsRedirect(bool $is_successful, bool $expected_is_redirect): void
+    {
+        $response = Mocker::mock('\Omnipay\Vindicia\Message\PayPalAuthorizeResponse', [
+            'isSuccessful' => $is_successful,
+        ])->makePartial();
+        $this->assertSame($expected_is_redirect, $response->isRedirect());
+    }
+
+    public function provideForTestIsRedirect(): array
+    {
+        // PayPal auths are always redirects so long as they are successful
+        return [
+            ['is_success' => true, 'expected_is_redirect' => true],
+            ['is_success' => false, 'expected_is_redirect' => false],
+        ];
+    }
+}

--- a/tests/Mock/PayPalAuthorizeFailure.xml
+++ b/tests/Mock/PayPalAuthorizeFailure.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:vin="http://soap.vindicia.com/v18_0/Vindicia"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <authResponse xmlns="http://soap.vindicia.com/v18_0/Transaction">
+      <return xmlns="" xsi:type="vin:Return">
+        <returnCode xsi:type="vin:ReturnCode">400</returnCode>
+        <soapId xsi:type="xsd:string">1234567890abcdef1234567890abcdef</soapId>
+        <returnString xsi:type="xsd:string">Authorization failed.</returnString>
+      </return>
+    </authResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/tests/Mock/PayPalAuthorizeSuccess.xml
+++ b/tests/Mock/PayPalAuthorizeSuccess.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:vin="http://soap.vindicia.com/v18_0/Vindicia"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <authResponse xmlns="http://soap.vindicia.com/v18_0/Transaction">
+      <return xmlns="" xsi:type="vin:Return">
+        <returnCode xsi:type="vin:ReturnCode">200</returnCode>
+        <soapId xsi:type="xsd:string">1234567890abcdef1234567890abcdef</soapId>
+        <returnString xsi:type="xsd:string">OK</returnString>
+      </return>
+      <transaction xmlns="" xsi:type="vin:Transaction">
+        <VID xmlns="" xsi:type="xsd:string">[TRANSACTION_REFERENCE]</VID>
+        <amount xmlns="" xsi:type="xsd:decimal">[AMOUNT]</amount>
+        <currency xmlns="" xsi:type="xsd:string">[CURRENCY]</currency>
+        <merchantTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</merchantTransactionId>
+        <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-12T11:51:26-07:00</timestamp>
+        <account xmlns="" xsi:type="vin:Account">
+          <VID xmlns="" xsi:type="xsd:string">[CUSTOMER_REFERENCE]</VID>
+          <merchantAccountId xmlns="" xsi:type="xsd:string">[CUSTOMER_ID]</merchantAccountId>
+          <emailAddress xmlns="" xsi:type="xsd:string">test@example.com</emailAddress>
+          <emailTypePreference xmlns="" xsi:type="vin:EmailPreference">html</emailTypePreference>
+          <name xmlns="" xsi:type="xsd:string">Test Customer</name>
+          <paymentMethods xmlns="" xsi:type="vin:PaymentMethod">
+            <VID xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_REFERENCE]</VID>
+            <type xmlns="" xsi:type="vin:PaymentMethodType">PayPal</type>
+            <paypal xmlns="" xsi:type="vin:PayPal">
+              <returnUrl xmlns="" xsi:type="xsd:string">[RETURN_URL]</returnUrl>
+              <cancelUrl xmlns="" xsi:type="xsd:string">[CANCEL_URL]</cancelUrl>
+              <requestReferenceId xmlns="" xsi:type="xsd:boolean">1</requestReferenceId>
+            </paypal>
+            <sortOrder xmlns="" xsi:type="xsd:int">0</sortOrder>
+            <active xmlns="" xsi:type="xsd:boolean">1</active>
+          </paymentMethods>
+        </account>
+        <sourcePaymentMethod xmlns="" xsi:type="vin:PaymentMethod">
+          <VID xmlns="" xsi:type="xsd:string">[PAYMENT_METHOD_REFERENCE]</VID>
+          <type xmlns="" xsi:type="vin:PaymentMethodType">PayPal</type>
+          <paypal xmlns="" xsi:type="vin:PayPal">
+            <returnUrl xmlns="" xsi:type="xsd:string">[RETURN_URL]</returnUrl>
+            <cancelUrl xmlns="" xsi:type="xsd:string">[CANCEL_URL]</cancelUrl>
+            <requestReferenceId xmlns="" xsi:type="xsd:boolean">1</requestReferenceId>
+          </paypal>
+          <sortOrder xmlns="" xsi:type="xsd:int">0</sortOrder>
+          <active xmlns="" xsi:type="xsd:boolean">1</active>
+        </sourcePaymentMethod>
+        <statusLog xmlns="" xsi:type="vin:TransactionStatus">
+          <status xmlns="" xsi:type="vin:TransactionStatusType">AuthorizationPending</status>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-12T11:51:27-07:00</timestamp>
+          <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">PayPal</paymentMethodType>
+          <payPalStatus xmlns="" xsi:type="vin:TransactionStatusPayPal">
+            <token xmlns="" xsi:type="xsd:string">[PAYPAL_TOKEN]</token>
+            <authCode xmlns="" xsi:type="xsd:string">000</authCode>
+            <redirectUrl xmlns="" xsi:type="xsd:string">https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&amp;useraction=commit&amp;token=[PAYPAL_TOKEN]</redirectUrl>
+          </payPalStatus>
+        </statusLog>
+        <statusLog xmlns="" xsi:type="vin:TransactionStatus">
+          <status xmlns="" xsi:type="vin:TransactionStatusType">New</status>
+          <timestamp xmlns="" xsi:type="xsd:dateTime">2016-10-12T11:51:25-07:00</timestamp>
+          <paymentMethodType xmlns="" xsi:type="vin:PaymentMethodType">PayPal</paymentMethodType>
+          <payPalStatus xmlns="" xsi:type="vin:TransactionStatusPayPal">
+            <token xmlns="" xsi:type="xsd:string">[PAYPAL_TOKEN]</token>
+            <authCode xmlns="" xsi:type="xsd:string">000</authCode>
+            <redirectUrl xmlns="" xsi:type="xsd:string">https://www.sandbox.paypal.com/webscr?cmd=_express-checkout&amp;useraction=commit&amp;token=[PAYPAL_TOKEN]</redirectUrl>
+          </payPalStatus>
+        </statusLog>
+        <paymentProcessor xmlns="" xsi:type="xsd:string">PayPal</paymentProcessor>
+        <paymentProcessorTransactionId xmlns="" xsi:type="xsd:string">[TRANSACTION_ID]</paymentProcessorTransactionId>
+        <transactionItems xmlns="" xsi:type="vin:TransactionItem">
+          <sku xmlns="" xsi:type="xsd:string">[SKU]</sku>
+          <indexNumber xmlns="" xsi:type="xsd:int">1</indexNumber>
+          <itemType xmlns="" xsi:type="vin:TransactionItemType">Purchase</itemType>
+          <name xmlns="" xsi:type="xsd:string">Item</name>
+          <price xmlns="" xsi:type="xsd:decimal">[AMOUNT]</price>
+          <quantity xmlns="" xsi:type="xsd:decimal">1</quantity>
+          <taxClassification xmlns="" xsi:type="xsd:string">OtherTaxable</taxClassification>
+          <taxType xmlns="" xsi:type="xsd:string">Exclusive Sales</taxType>
+          <subtotal xmlns="" xsi:type="xsd:decimal">[AMOUNT]</subtotal>
+          <total xmlns="" xsi:type="xsd:decimal">[AMOUNT]</total>
+        </transactionItems>
+        <transactionItems xmlns="" xsi:type="vin:TransactionItem">
+          <sku xmlns="" xsi:type="xsd:string">Total Tax</sku>
+          <indexNumber xmlns="" xsi:type="xsd:int">2</indexNumber>
+          <itemType xmlns="" xsi:type="vin:TransactionItemType">Purchase</itemType>
+          <name xmlns="" xsi:type="xsd:string">Total Tax</name>
+          <price xmlns="" xsi:type="xsd:decimal">0</price>
+          <quantity xmlns="" xsi:type="xsd:decimal">1</quantity>
+          <taxClassification xmlns="" xsi:type="xsd:string">TaxExempt</taxClassification>
+          <taxType xmlns="" xsi:type="xsd:string">Exclusive Sales</taxType>
+          <discount xmlns="" xsi:type="xsd:decimal">0</discount>
+          <subtotal xmlns="" xsi:type="xsd:decimal">0</subtotal>
+          <total xmlns="" xsi:type="xsd:decimal">0</total>
+        </transactionItems>
+        <nameValues xmlns="" xsi:type="vin:NameValuePair">
+          <name xmlns="" xsi:type="xsd:string">[ATTRIBUTE_1_NAME]</name>
+          <value xmlns="" xsi:type="xsd:string">[ATTRIBUTE_1_VALUE]</value>
+        </nameValues>
+        <nameValues xmlns="" xsi:type="vin:NameValuePair">
+          <name xmlns="" xsi:type="xsd:string">[ATTRIBUTE_2_NAME]</name>
+          <value xmlns="" xsi:type="xsd:string">[ATTRIBUTE_2_VALUE]</value>
+        </nameValues>
+      </transaction>
+      <score xmlns="" xsi:type="xsd:int">[RISK_SCORE]</score>
+    </authResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/tests/PayPalGatewayTest.php
+++ b/tests/PayPalGatewayTest.php
@@ -71,6 +71,35 @@ class PayPalGatewayTest extends GatewayTestCase
     /**
      * @return void
      */
+    public function testAuthorize()
+    {
+        $currency = $this->faker->currency();
+        $amount = $this->faker->monetaryAmount($currency);
+        $customerId = $this->faker->customerId();
+        $returnUrl = $this->faker->url();
+        $cancelUrl = $this->faker->url();
+
+        $request = $this->gateway->authorize(
+            array(
+                'amount' => $amount,
+                'currency' => $currency,
+                'customerId' => $customerId,
+                'returnUrl' => $returnUrl,
+                'cancelUrl' => $cancelUrl
+            )
+        );
+
+        $this->assertInstanceOf('Omnipay\Vindicia\Message\PayPalAuthorizeRequest', $request);
+        $this->assertSame($amount, $request->getAmount());
+        $this->assertSame($currency, $request->getCurrency());
+        $this->assertSame($customerId, $request->getCustomerId());
+        $this->assertSame($returnUrl, $request->getReturnUrl());
+        $this->assertSame($cancelUrl, $request->getCancelUrl());
+    }
+
+    /**
+     * @return void
+     */
     public function testPurchase()
     {
         $currency = $this->faker->currency();


### PR DESCRIPTION
This can be used to authorize a PayPal payment method before starting a free trial.

There is a lot of new stuff but is heavily based on existing tests and mock responses for `PayPalPurchaseRequest`.