### PR TITLE
Fix the return type of PayPalGateway::authorize

### DIFF
--- a/src/PayPalGateway.php
+++ b/src/PayPalGateway.php
@@ -77,7 +77,7 @@ class PayPalGateway extends AbstractVindiciaGateway
     /**
      * Authorize a transaction. No money will actually be transferred.
      * 
-     * @return PayPalAuthorizeRequest
+     * @return \Omnipay\Vindicia\Message\PayPalAuthorizeRequest
      */
     public function authorize($parameters = array())
     {


### PR DESCRIPTION
The return type must be fully qualified here to be correctly recognized.