### PR TITLE
Add option to record all test soap calls

### DIFF
--- a/src/RecordedSoapCall.php
+++ b/src/RecordedSoapCall.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omnipay\Vindicia;
+
+class RecordedSoapCall
+{
+    /**
+     * @var string
+     */
+    private $function_name;
+
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    public function __construct(string $function_name, array $arguments) 
+    {
+        $this->function_name = $function_name;
+        $this->arguments = $arguments;
+    }
+
+    public function getFunctionName(): string
+    {
+        return $this->function_name;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+}


### PR DESCRIPTION
This adds the option to record all test SOAP calls made in `TestableSoapClient`. This option is off by default.