### PR TITLE
Allow queued throwables from test soap calls

### DIFF
--- a/src/TestableSoapClient.php
+++ b/src/TestableSoapClient.php
@@ -96,8 +96,11 @@ class TestableSoapClient extends SoapClient
             self::$lastArguments = $arguments;
             self::$lastFunctionName = $function_name;
 
-            $return = self::$nextResponseOverrideQueue->dequeue();
-            return $return;
+            $response = self::$nextResponseOverrideQueue->dequeue();
+            if ($response instanceof \Throwable) {
+                throw $response;
+            }
+            return $response;
         }
 
         return parent::__soapCall($function_name, $arguments);


### PR DESCRIPTION
This can be used to setup a soap call exception as part of a test without having to mock `TestableSoapClient` with a Mockery overload prefix (or something similar). Instead, `TestableSoapClient::setNextResponse` can be used to set the desired exception as the next "response".